### PR TITLE
Code quality fix - "equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -289,6 +289,20 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
         }
 
         @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((guard == null) ? 0 : guard.hashCode());
+            result = prime * result
+                    + ((sourceVertex == null) ? 0 : sourceVertex.hashCode());
+            result = prime * result
+                    + ((targetVertex == null) ? 0 : targetVertex.hashCode());
+            result = prime * result
+                    + ((weight == null) ? 0 : weight.hashCode());
+            return result;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (isNull(o) || getClass() != o.getClass()) return false;
@@ -299,5 +313,7 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
                     Objects.equals(guard, that.guard) &&
                     Objects.equals(weight, that.weight);
         }
+
+        
     }
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Model.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Model.java
@@ -569,6 +569,46 @@ public final class Model extends BuilderBase<Model, Model.RuntimeModel> {
         }
 
         @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((edges == null) ? 0 : edges.hashCode());
+            result = prime
+                    * result
+                    + ((edgesByNameCache == null) ? 0 : edgesByNameCache
+                            .hashCode());
+            result = prime
+                    * result
+                    + ((elementsByElementCache == null) ? 0
+                            : elementsByElementCache.hashCode());
+            result = prime
+                    * result
+                    + ((elementsByNameCache == null) ? 0 : elementsByNameCache
+                            .hashCode());
+            result = prime * result
+                    + ((elementsCache == null) ? 0 : elementsCache.hashCode());
+            result = prime
+                    * result
+                    + ((inEdgesByVertexCache == null) ? 0
+                            : inEdgesByVertexCache.hashCode());
+            result = prime
+                    * result
+                    + ((outEdgesByVertexCache == null) ? 0
+                            : outEdgesByVertexCache.hashCode());
+            result = prime
+                    * result
+                    + ((sharedStateCache == null) ? 0 : sharedStateCache
+                            .hashCode());
+            result = prime * result
+                    + ((vertices == null) ? 0 : vertices.hashCode());
+            result = prime
+                    * result
+                    + ((verticesByNameCache == null) ? 0 : verticesByNameCache
+                            .hashCode());
+            return result;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (isNull(o) || getClass() != o.getClass()) return false;
@@ -585,5 +625,6 @@ public final class Model extends BuilderBase<Model, Model.RuntimeModel> {
                     Objects.equals(outEdgesByVertexCache, that.outEdgesByVertexCache) &&
                     Objects.equals(sharedStateCache, that.sharedStateCache);
         }
+        
     }
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/RuntimeBase.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/RuntimeBase.java
@@ -136,6 +136,20 @@ public abstract class RuntimeBase implements Element {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((actions == null) ? 0 : actions.hashCode());
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result
+                + ((properties == null) ? 0 : properties.hashCode());
+        result = prime * result
+                + ((requirements == null) ? 0 : requirements.hashCode());
+        return result;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (isNull(o) || getClass() != o.getClass()) return false;
@@ -146,4 +160,5 @@ public abstract class RuntimeBase implements Element {
                 Objects.equals(requirements, that.requirements) &&
                 Objects.equals(properties, that.properties);
     }
+
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Vertex.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Vertex.java
@@ -136,6 +136,15 @@ public final class Vertex extends CachedBuilder<Vertex, Vertex.RuntimeVertex> {
         }
 
         @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = super.hashCode();
+            result = prime * result
+                    + ((sharedState == null) ? 0 : sharedState.hashCode());
+            return result;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (isNull(o) || getClass() != o.getClass()) return false;
@@ -143,5 +152,6 @@ public final class Vertex extends CachedBuilder<Vertex, Vertex.RuntimeVertex> {
             RuntimeVertex that = (RuntimeVertex) o;
             return Objects.equals(sharedState, that.sharedState);
         }
+
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1206- "equals(Object obj)" and "hashCode()" should be overridden in pairs
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1206

Please let me know if you have any questions.

Faisal Hameed