### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/common/Objects.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/common/Objects.java
@@ -13,6 +13,8 @@ import java.util.Set;
  * @author Nils Olsson
  */
 public class Objects {
+    
+    private Objects() {}
 
     public static <K, V> boolean isNullOrEmpty(Map<K, V> map) {
         return !isNotNullOrEmpty(map);

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorFactory.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorFactory.java
@@ -39,6 +39,9 @@ import org.graphwalker.dsl.generator.Logical_Lexer;
  * Created by krikar on 5/14/14.
  */
 public class GeneratorFactory {
+    
+    private GeneratorFactory() {}
+    
     public static PathGenerator parse(String str) {
         ANTLRInputStream inputStream = new ANTLRInputStream(str);
         Logical_Lexer lexer = new Logical_Lexer(inputStream);

--- a/graphwalker-io/src/main/java/org/graphwalker/io/common/Util.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/common/Util.java
@@ -38,6 +38,9 @@ import java.util.ListIterator;
  * Created by krikar on 2015-11-04.
  */
 public class Util {
+    
+    private Util() {}
+    
     /*
      * Search the elements for a specific property: blocked.
      * If it exists, the element will be removed from

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/ContextFactoryScanner.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/ContextFactoryScanner.java
@@ -42,6 +42,8 @@ import java.util.*;
  * @author Nils Olsson
  */
 public final class ContextFactoryScanner {
+    
+    private ContextFactoryScanner() {}
 
     private static final Logger logger = LoggerFactory.getLogger(ContextFactoryScanner.class);
 

--- a/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ContextChecker.java
+++ b/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ContextChecker.java
@@ -12,6 +12,8 @@ import java.util.List;
  * Created by krikar on 2015-11-08.
  */
 public class ContextChecker {
+    
+    private ContextChecker() {}
 
     /**
      * Checks the context for problems or any possible errors.

--- a/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/EdgeChecker.java
+++ b/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/EdgeChecker.java
@@ -11,6 +11,8 @@ import java.util.List;
  */
 public class EdgeChecker {
 
+    private EdgeChecker() {}
+    
     /**
      * Checks the edge for problems or any possible errors.
      * Any findings will be added to a list of strings.

--- a/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ElementChecker.java
+++ b/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ElementChecker.java
@@ -11,6 +11,9 @@ import java.util.List;
  * Created by krikar on 2015-11-08.
  */
 public class ElementChecker {
+    
+    private ElementChecker() {}
+    
     /**
      * Checks for problems or any possible errors.
      * Any findings will be added to a list of strings.

--- a/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ModelChecker.java
+++ b/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/ModelChecker.java
@@ -14,6 +14,9 @@ import java.util.Set;
  * Created by krikar on 2015-11-08.
  */
 public class ModelChecker {
+    
+    private ModelChecker() {}
+    
     /**
      * Checks the model for problems or any possible errors.
      * Any findings will be added to a list of strings.

--- a/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/VertexChecker.java
+++ b/graphwalker-model-checker/src/main/java/org/graphwalker/modelchecker/VertexChecker.java
@@ -10,6 +10,9 @@ import java.util.List;
  * Created by krikar on 2015-11-08.
  */
 public class VertexChecker {
+    
+    private VertexChecker() {}
+    
     /**
      * Checks the vertex for problems or any possible errors.
      * Any findings will be added to a list of strings.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed