### PR TITLE
General code quality fix-3

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/algorithm/FloydWarshall.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/algorithm/FloydWarshall.java
@@ -59,7 +59,7 @@ public final class FloydWarshall implements Algorithm {
             if (element instanceof RuntimeEdge) {
                 RuntimeEdge edge = (RuntimeEdge) element;
                 RuntimeVertex target = edge.getTargetVertex();
-                distances[elements.indexOf(edge)][elements.indexOf(target)] = (int) Math.ceil(1);
+                distances[elements.indexOf(edge)][elements.indexOf(target)] = 1;
             } else if (element instanceof RuntimeVertex) {
                 RuntimeVertex vertex = (RuntimeVertex) element;
                 for (RuntimeEdge edge : model.getOutEdges(vertex)) {

--- a/graphwalker-gradle-plugin/src/main/java/org/graphwalker/gradle/plugin/task/ExecuteTests.java
+++ b/graphwalker-gradle-plugin/src/main/java/org/graphwalker/gradle/plugin/task/ExecuteTests.java
@@ -73,8 +73,7 @@ public class ExecuteTests extends TaskBase {
     }
 
     private Configuration createConfiguration() {
-        Configuration configuration = new Configuration();
-        return configuration;
+        return new Configuration();
     }
 
     private List<String> getClasspathElements() {

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/java/JavaContextFactory.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/java/JavaContextFactory.java
@@ -124,7 +124,7 @@ public final class JavaContextFactory implements ContextFactory {
         int index = 0;
         String add_vertices = "";
         for (Vertex.RuntimeVertex vertex : context.getModel().getVertices()) {
-            String id = "";
+            String id;
             if (vertex.getId() != null && !vertex.getId().equals("")) {
                 id = vertex.getId();
             } else {

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/yed/YEdContextFactory.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/yed/YEdContextFactory.java
@@ -115,7 +115,7 @@ public final class YEdContextFactory implements ContextFactory {
 
     @Override
     public <T extends Context> T create(Path path, T context) {
-        Edge startEdge = null;
+        Edge startEdge;
         Map<String, Vertex> elements = new HashMap<>();
         Model model = new Model();
         GraphmlDocument document = null;

--- a/graphwalker-restful/src/main/java/org/graphwalker/restful/Util.java
+++ b/graphwalker-restful/src/main/java/org/graphwalker/restful/Util.java
@@ -36,6 +36,7 @@ import org.graphwalker.core.model.RuntimeBase;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -120,7 +121,7 @@ public abstract class Util {
      * @return The execution statistics in JSON format.
      */
     public static JSONObject getStatisticsAsJSON(Machine machine) {
-        HashMap<Statistics, Integer> map = getStatistics(machine.getCurrentContext());
+        EnumMap<Statistics, Integer> map = getStatistics(machine.getCurrentContext());
         JSONObject object = new JSONObject();
         object.put("totalNumberOfEdges", map.get(Statistics.TOTAL_NUMBER_OF_EDGES));
         object.put("totalNumberOfUnvisitedEdges", map.get(Statistics.TOTAL_NUMBER_OF_UNVISITED_EDGES));
@@ -165,8 +166,8 @@ public abstract class Util {
         return object;
     }
 
-    private static HashMap<Statistics, Integer> getStatistics(Context context) {
-        HashMap<Statistics, Integer> map = new HashMap<>();
+    private static EnumMap<Statistics, Integer> getStatistics(Context context) {
+        EnumMap<Statistics, Integer> map = new EnumMap<>(Statistics.class);
         map.put(Statistics.TOTAL_NUMBER_OF_VERTICES, context.getModel().getVertices().size());
         map.put(Statistics.TOTAL_NUMBER_OF_UNVISITED_VERTICES, context.getProfiler().getUnvisitedVertices(context).size());
         map.put(Statistics.TOTAL_NUMBER_OF_EDGES, context.getModel().getEdges().size());


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1854 - Dead stores should be removed. 
squid:S2185- Silly math should not be performed.
squid:S1640- Maps with keys that are enum values should be replaced with EnumMap.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S2185
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1640

Please let me know if you have any questions.
 
Faisal Hameed