### PR TITLE
Dependency Stop Condition

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyCoverageStopConditionBase.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyCoverageStopConditionBase.java
@@ -5,30 +5,16 @@ package org.graphwalker.core.condition;
  */
 public abstract class DependencyCoverageStopConditionBase extends StopConditionBase {
 
-	private final int percent;
-
 	private final int dependency;
 
-	protected DependencyCoverageStopConditionBase(int percent, int dependency) {
-		super(String.valueOf(percent));
-		if (0 > percent) {
-			throw new StopConditionException("A coverage cannot be negative");
-		}
-		this.percent = percent;
+	protected DependencyCoverageStopConditionBase(int dependency) {
+		super(String.valueOf(dependency));
 		if (0 > dependency) {
 			throw new StopConditionException("A dependency cannot be negative");
 		}
 		this.dependency = dependency;
 	}
-
-	public int getPercent() {
-		return percent;
-	}
-
-	protected double getPercentAsDouble() {
-		return (double) getPercent() / 100;
-	}
-
+	
 	public int getDependency() {
 		return dependency;
 	}

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyCoverageStopConditionBase.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyCoverageStopConditionBase.java
@@ -1,0 +1,39 @@
+package org.graphwalker.core.condition;
+
+/**
+ * @author Miroslav Janeski
+ */
+public abstract class DependencyCoverageStopConditionBase extends StopConditionBase {
+
+	private final int percent;
+
+	private final int dependency;
+
+	protected DependencyCoverageStopConditionBase(int percent, int dependency) {
+		super(String.valueOf(percent));
+		if (0 > percent) {
+			throw new StopConditionException("A coverage cannot be negative");
+		}
+		this.percent = percent;
+		if (0 > dependency) {
+			throw new StopConditionException("A dependency cannot be negative");
+		}
+		this.dependency = dependency;
+	}
+
+	public int getPercent() {
+		return percent;
+	}
+
+	protected double getPercentAsDouble() {
+		return (double) getPercent() / 100;
+	}
+
+	public int getDependency() {
+		return dependency;
+	}
+
+	protected double getDependencyAsDouble() {
+		return (double) getDependency() / 100;
+	}
+}

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -1,0 +1,70 @@
+package org.graphwalker.core.condition;
+
+/*
+ * #%L
+ * GraphWalker Core
+ * %%
+ * Copyright (C) 2005 - 2014 GraphWalker
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import org.graphwalker.core.machine.Context;
+
+import static org.graphwalker.core.model.Edge.RuntimeEdge;
+
+/**
+ * <h1>DependencyEdgeCoverage</h1> The EdgeCoverage stop condition is fulfilled
+ * when the percentage of visited edges in the model is greater than, or equal,
+ * to the percentage given as a parameter to the constructor.
+ * </p>
+ *
+ * @author Miroslav Janeski
+ */
+public final class DependencyEdgeCoverage extends DependencyCoverageStopConditionBase {
+
+	public DependencyEdgeCoverage(int percent, int dependency) {
+		super(percent, dependency);
+	}
+
+	@Override
+	public boolean isFulfilled() {
+		boolean temp = super.isFulfilled();
+		return getFulfilment() >= super.getPercentAsDouble() && super.isFulfilled();
+	}
+
+	@Override
+	public double getFulfilment() {
+		Context context = getContext();
+
+		long totalEdgesCount = 0;
+		long visitedEdgesCount = 0;
+		for (RuntimeEdge edge : context.getModel().getEdges()) {
+			if (edge.getDependency() >= super.getDependencyAsDouble()) {
+				totalEdgesCount++;
+			}
+			if (context.getProfiler().isVisited(edge) && edge.getDependency() >= super.getDependencyAsDouble()) {
+				visitedEdgesCount++;
+			}
+		}
+
+		return ((double) visitedEdgesCount / totalEdgesCount) / getPercentAsDouble();
+	}
+}

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -40,8 +40,8 @@ import static org.graphwalker.core.model.Edge.RuntimeEdge;
  */
 public final class DependencyEdgeCoverage extends DependencyCoverageStopConditionBase {
 
-	public DependencyEdgeCoverage(int percent, int dependency) {
-		super(percent, dependency);
+	public DependencyEdgeCoverage(int dependency) {
+		super(dependency);
 	}
 
 	@Override
@@ -54,25 +54,20 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 		Context context = getContext();
 		long totalDependencyEdgesCount = 0;
 		long visitedDependencyEdgesCount = 0;
-		long totalEdgesCount = 0;
-		long visitedEdgesCount = 0;
 		for (RuntimeEdge edge : context.getModel().getEdges()) {
-			totalEdgesCount++;
 			if (edge.getDependency() >= super.getDependencyAsDouble()) {
 				totalDependencyEdgesCount++;
 			}
 			if (context.getProfiler().isVisited(edge)) {
-				visitedEdgesCount++;
 				if (edge.getDependency() >= super.getDependencyAsDouble()) {
 					visitedDependencyEdgesCount++;
 				}
-
 			}
 		}
 
-		if (totalDependencyEdgesCount > 0) {
-			return ((double) visitedDependencyEdgesCount / totalDependencyEdgesCount);
+		if (totalDependencyEdgesCount == 0) {
+			return totalDependencyEdgesCount;
 		}
-		return ((double) visitedEdgesCount / totalEdgesCount);
+		return ((double) visitedDependencyEdgesCount / totalDependencyEdgesCount);
 	}
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -57,12 +57,10 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 		for (RuntimeEdge edge : context.getModel().getEdges()) {
 			if (edge.getDependency() >= super.getDependencyAsDouble()) {
 				totalDependencyEdgesCount++;
-			}
-			if (context.getProfiler().isVisited(edge)) {
-				if (edge.getDependency() >= super.getDependencyAsDouble()) {
+				if (context.getProfiler().isVisited(edge)) {
 					visitedDependencyEdgesCount++;
-				}
-			}
+				}				
+			}	
 		}
 
 		if (totalDependencyEdgesCount == 0) {

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -46,25 +46,33 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 
 	@Override
 	public boolean isFulfilled() {
-		boolean temp = super.isFulfilled();
-		return getFulfilment() >= super.getPercentAsDouble() && super.isFulfilled();
+		return getFulfilment() >= super.getDependencyAsDouble() && super.isFulfilled();
 	}
 
 	@Override
 	public double getFulfilment() {
 		Context context = getContext();
-
+		long totalDependencyEdgesCount = 0;
+		long visitedDependencyEdgesCount = 0;
 		long totalEdgesCount = 0;
 		long visitedEdgesCount = 0;
 		for (RuntimeEdge edge : context.getModel().getEdges()) {
+			totalEdgesCount++;
 			if (edge.getDependency() >= super.getDependencyAsDouble()) {
-				totalEdgesCount++;
+				totalDependencyEdgesCount++;
 			}
-			if (context.getProfiler().isVisited(edge) && edge.getDependency() >= super.getDependencyAsDouble()) {
+			if (context.getProfiler().isVisited(edge)) {
 				visitedEdgesCount++;
+				if (edge.getDependency() >= super.getDependencyAsDouble()) {
+					visitedDependencyEdgesCount++;
+				}
+
 			}
 		}
 
-		return ((double) visitedEdgesCount / totalEdgesCount) / getPercentAsDouble();
+		if (totalDependencyEdgesCount > 0) {
+			return ((double) visitedDependencyEdgesCount / totalDependencyEdgesCount);
+		}
+		return ((double) visitedEdgesCount / totalEdgesCount);
 	}
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -31,9 +31,9 @@ import org.graphwalker.core.machine.Context;
 import static org.graphwalker.core.model.Edge.RuntimeEdge;
 
 /**
- * <h1>DependencyEdgeCoverage</h1> The EdgeCoverage stop condition is fulfilled
- * when the percentage of visited edges in the model is greater than, or equal,
- * to the percentage given as a parameter to the constructor.
+ * <h1>DependencyEdgeCoverage</h1> The DependencyEdgeCoverage stop condition is fulfilled
+ * when all the edges with dependency greater than, or equal,
+ * to the dependency given as a parameter to the constructor, are visited.
  * </p>
  *
  * @author Miroslav Janeski
@@ -46,7 +46,7 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 
 	@Override
 	public boolean isFulfilled() {
-		return getFulfilment() >= super.getDependencyAsDouble() && super.isFulfilled();
+		return getFulfilment() >= FULFILLMENT_LEVEL && super.isFulfilled();
 	}
 
 	@Override
@@ -67,7 +67,8 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 
 		if (totalDependencyEdgesCount == 0) {
 			return totalDependencyEdgesCount;
+		} else {
+			return ((double) visitedDependencyEdgesCount / totalDependencyEdgesCount);
 		}
-		return ((double) visitedDependencyEdgesCount / totalDependencyEdgesCount);
 	}
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/DependencyEdgeCoverage.java
@@ -55,7 +55,7 @@ public final class DependencyEdgeCoverage extends DependencyCoverageStopConditio
 		long totalDependencyEdgesCount = 0;
 		long visitedDependencyEdgesCount = 0;
 		for (RuntimeEdge edge : context.getModel().getEdges()) {
-			if (edge.getDependency() >= super.getDependencyAsDouble()) {
+			if (edge.getDependencyAsDouble() >= super.getDependencyAsDouble()) {
 				totalDependencyEdgesCount++;
 				if (context.getProfiler().isVisited(edge)) {
 					visitedDependencyEdgesCount++;

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -39,281 +39,304 @@ import static org.graphwalker.core.common.Objects.unmodifiableList;
 import static org.graphwalker.core.model.Vertex.RuntimeVertex;
 
 /**
- * <h1>Edge</h1>
- * The  Edge holds the information for a transition in a model.
+ * <h1>Edge</h1> The Edge holds the information for a transition in a model.
  * </p>
  * The edge represents an action performed by a test, which takes the system
- * under test, from a state to another.
- * The edge has a source and target vertex. If the vertices are identical, the
- * edge is a self loop. The source vertex is not mandatory, but in a model,
- * there should be only one such instance. Also, the target vertex is not
- * mandatory, but again, in a model, there should be only one such instance.
+ * under test, from a state to another. The edge has a source and target vertex.
+ * If the vertices are identical, the edge is a self loop. The source vertex is
+ * not mandatory, but in a model, there should be only one such instance. Also,
+ * the target vertex is not mandatory, but again, in a model, there should be
+ * only one such instance.
  *
  * @author Nils Olsson
  */
 public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
 
-  private Vertex sourceVertex;
-  private Vertex targetVertex;
-  private Guard guard;
-  private List<Action> actions = new ArrayList<>();
-  private Double weight = 0.0;
+	private Vertex sourceVertex;
+	private Vertex targetVertex;
+	private Guard guard;
+	private List<Action> actions = new ArrayList<>();
+	private Double weight = 0.0;
+	private Double dependency = 0.0;
 
-  /**
-   * Sets the source vertex of the edge.
-   *
-   * @param vertex The source vertex.
-   * @return The edge.
-   */
-  public Edge setSourceVertex(Vertex vertex) {
-    this.sourceVertex = vertex;
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * Sets the source vertex of the edge.
+	 *
+	 * @param vertex
+	 *            The source vertex.
+	 * @return The edge.
+	 */
+	public Edge setSourceVertex(Vertex vertex) {
+		this.sourceVertex = vertex;
+		invalidateCache();
+		return this;
+	}
 
-  /**
-   * Gets the source vertex.
-   *
-   * @return The source vertex.
-   * @see Edge#setSourceVertex
-   */
-  public Vertex getSourceVertex() {
-    return sourceVertex;
-  }
+	/**
+	 * Gets the source vertex.
+	 *
+	 * @return The source vertex.
+	 * @see Edge#setSourceVertex
+	 */
+	public Vertex getSourceVertex() {
+		return sourceVertex;
+	}
 
-  /**
-   * Sets the target vertex of the edge.
-   *
-   * @param vertex The target vertex.
-   * @return The edge.
-   */
-  public Edge setTargetVertex(Vertex vertex) {
-    this.targetVertex = vertex;
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * Sets the target vertex of the edge.
+	 *
+	 * @param vertex
+	 *            The target vertex.
+	 * @return The edge.
+	 */
+	public Edge setTargetVertex(Vertex vertex) {
+		this.targetVertex = vertex;
+		invalidateCache();
+		return this;
+	}
 
-  /**
-   * Gets the target vertex of the edge.
-   *
-   * @return The vertex.
-   * @see Edge#setTargetVertex
-   */
-  public Vertex getTargetVertex() {
-    return targetVertex;
-  }
+	/**
+	 * Gets the target vertex of the edge.
+	 *
+	 * @return The vertex.
+	 * @see Edge#setTargetVertex
+	 */
+	public Vertex getTargetVertex() {
+		return targetVertex;
+	}
 
-  /**
-   * Sets the guard of the edge. The code in the guard is by default interpreted as javascript.
-   * The guard works like an 'if-statement'. It controls the accessibility of the edge.
-   * During execution, the guard evaluates to a boolean expression.
-   * If true, the edge is accessible, else it's not.
-   *
-   * @param guard The guard.
-   * @return The edge.
-   */
-  public Edge setGuard(Guard guard) {
-    this.guard = guard;
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * Sets the guard of the edge. The code in the guard is by default
+	 * interpreted as javascript. The guard works like an 'if-statement'. It
+	 * controls the accessibility of the edge. During execution, the guard
+	 * evaluates to a boolean expression. If true, the edge is accessible, else
+	 * it's not.
+	 *
+	 * @param guard
+	 *            The guard.
+	 * @return The edge.
+	 */
+	public Edge setGuard(Guard guard) {
+		this.guard = guard;
+		invalidateCache();
+		return this;
+	}
 
-  /**
-   * Gets the guard of the edge.
-   *
-   * @return The guard.
-   * @see Edge#setGuard
-   */
-  public Guard getGuard() {
-    return guard;
-  }
+	/**
+	 * Gets the guard of the edge.
+	 *
+	 * @return The guard.
+	 * @see Edge#setGuard
+	 */
+	public Guard getGuard() {
+		return guard;
+	}
 
-  /**
-   * Adds an action to the edge, which represents a piece of code that will be executed
-   * each time the edge is being traversed. The code is by default interpreted as javascript.
-   *
-   * @param action The action.
-   * @return The edge.
-   */
-  public Edge addAction(Action action) {
-    this.actions.add(action);
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * Adds an action to the edge, which represents a piece of code that will be
+	 * executed each time the edge is being traversed. The code is by default
+	 * interpreted as javascript.
+	 *
+	 * @param action
+	 *            The action.
+	 * @return The edge.
+	 */
+	public Edge addAction(Action action) {
+		this.actions.add(action);
+		invalidateCache();
+		return this;
+	}
 
-  public Edge addActions(Action... actions) {
-    return addActions(Arrays.asList(actions));
-  }
+	public Edge addActions(Action... actions) {
+		return addActions(Arrays.asList(actions));
+	}
 
-  public Edge addActions(List<Action> actions) {
-    this.actions.addAll(actions);
-    return this;
-  }
+	public Edge addActions(List<Action> actions) {
+		this.actions.addAll(actions);
+		return this;
+	}
 
-  /**
-   * Adds a list of actions to the edge, which represents a pieces of code that will be executed
-   * each time the edge is being traversed. The code snippets is by default interpreted as javascript.
-   *
-   * @param actions The actions.
-   * @return The edge.
-   * @see Edge#addAction
-   */
-  public Edge setActions(List<Action> actions) {
-    this.actions = new ArrayList<>(actions);
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * Adds a list of actions to the edge, which represents a pieces of code
+	 * that will be executed each time the edge is being traversed. The code
+	 * snippets is by default interpreted as javascript.
+	 *
+	 * @param actions
+	 *            The actions.
+	 * @return The edge.
+	 * @see Edge#addAction
+	 */
+	public Edge setActions(List<Action> actions) {
+		this.actions = new ArrayList<>(actions);
+		invalidateCache();
+		return this;
+	}
 
-  /**
-   * Gets the lists of actions of the edge.
-   *
-   * @return The actions
-   * @see Edge#setActions
-   */
-  public List<Action> getActions() {
-    return unmodifiableList(actions);
-  }
+	/**
+	 * Gets the lists of actions of the edge.
+	 *
+	 * @return The actions
+	 * @see Edge#setActions
+	 */
+	public List<Action> getActions() {
+		return unmodifiableList(actions);
+	}
 
-  /**
-   * Gets the weight of the edge.
-   *
-   * @return The weight as double.
-   * @see Edge#setWeight
-   */
-  public Double getWeight() {
-    return weight;
-  }
+	/**
+	 * Gets the weight of the edge.
+	 *
+	 * @return The weight as double.
+	 * @see Edge#setWeight
+	 */
+	public Double getWeight() {
+		return weight;
+	}
 
-  /**
-   * The weight is used as probability when using the {@link org.graphwalker.core.generator.WeightedRandomPath}.
-   * Weight means the probability for the edge to be selected.
-   *
-   * @param weight a double between 0 and 1
-   * @return The edge
-   */
-  public Edge setWeight(Double weight) {
-    this.weight = weight;
-    invalidateCache();
-    return this;
-  }
+	/**
+	 * The weight is used as probability when using the
+	 * {@link org.graphwalker.core.generator.WeightedRandomPath}. Weight means
+	 * the probability for the edge to be selected.
+	 *
+	 * @param weight
+	 *            a double between 0 and 1
+	 * @return The edge
+	 */
+	public Edge setWeight(Double weight) {
+		this.weight = weight;
+		invalidateCache();
+		return this;
+	}
 
-  /**
-   * Creates an immutable edge from this edge.
-   *
-   * @return An immutable edge as a RuntimeEdge
-   */
-  @Override
-  protected RuntimeEdge createCache() {
-    return new RuntimeEdge(this);
-  }
+	/**
+	 * Creates an immutable edge from this edge.
+	 *
+	 * @return An immutable edge as a RuntimeEdge
+	 */
+	@Override
+	protected RuntimeEdge createCache() {
+		return new RuntimeEdge(this);
+	}
 
-  /**
-   * <h1>RuntimeEdge</h1>
-   * Immutable class for Edge
-   * </p>
-   * This class is used in models. It guarantees that that the internal states of
-   * the instance will not change after it's construction.
-   * </p>
-   */
-  public static final class RuntimeEdge extends RuntimeBase {
+	public Double getDependency() {
+		return dependency;
+	}
 
-    private final RuntimeVertex sourceVertex;
-    private final RuntimeVertex targetVertex;
-    private final Guard guard;
-    private final Double weight;
+	public Edge setDependency(Double dependency) {
+		this.dependency = dependency;
+		invalidateCache();
+		return this;
+	}
 
-    private RuntimeEdge(Edge edge) {
-      super(edge.getId(), edge.getName(), edge.getActions(), edge.getRequirements(), edge.getProperties());
-      this.sourceVertex = build(edge.getSourceVertex());
-      this.targetVertex = build(edge.getTargetVertex());
-      this.guard = edge.getGuard();
-      this.weight = edge.getWeight();
-    }
+	/**
+	 * <h1>RuntimeEdge</h1> Immutable class for Edge
+	 * </p>
+	 * This class is used in models. It guarantees that that the internal states
+	 * of the instance will not change after it's construction.
+	 * </p>
+	 */
+	public static final class RuntimeEdge extends RuntimeBase {
 
-    private <T> T build(Builder<T> builder) {
-      return isNotNull(builder) ? builder.build() : null;
-    }
+		private final RuntimeVertex sourceVertex;
+		private final RuntimeVertex targetVertex;
+		private final Guard guard;
+		private final Double weight;
+        private final Double dependency;
+        
+		private RuntimeEdge(Edge edge) {
+			super(edge.getId(), edge.getName(), edge.getActions(), edge.getRequirements(), edge.getProperties());
+			this.sourceVertex = build(edge.getSourceVertex());
+			this.targetVertex = build(edge.getTargetVertex());
+			this.guard = edge.getGuard();
+			this.weight = edge.getWeight();
+			this.dependency = edge.getDependency();
+		}
 
-    /**
-     * Gets the source vertex.
-     *
-     * @return The source vertex.
-     * @see Edge#setSourceVertex
-     */
-    public RuntimeVertex getSourceVertex() {
-      return sourceVertex;
-    }
+		private <T> T build(Builder<T> builder) {
+			return isNotNull(builder) ? builder.build() : null;
+		}
 
-    /**
-     * Gets the target vertex of the edge.
-     *
-     * @return The vertex.
-     * @see Edge#setTargetVertex
-     */
-    public RuntimeVertex getTargetVertex() {
-      return targetVertex;
-    }
+		/**
+		 * Gets the source vertex.
+		 *
+		 * @return The source vertex.
+		 * @see Edge#setSourceVertex
+		 */
+		public RuntimeVertex getSourceVertex() {
+			return sourceVertex;
+		}
 
-    /**
-     * Gets the guard of the edge.
-     *
-     * @return The guard.
-     * @see Edge#setGuard
-     */
-    public Guard getGuard() {
-      return guard;
-    }
+		/**
+		 * Gets the target vertex of the edge.
+		 *
+		 * @return The vertex.
+		 * @see Edge#setTargetVertex
+		 */
+		public RuntimeVertex getTargetVertex() {
+			return targetVertex;
+		}
 
-    public boolean hasGuard() {
-      return isNotNull(guard) && isNotNullOrEmpty(guard.getScript());
-    }
+		/**
+		 * Gets the guard of the edge.
+		 *
+		 * @return The guard.
+		 * @see Edge#setGuard
+		 */
+		public Guard getGuard() {
+			return guard;
+		}
 
-    /**
-     * Gets the weight of the edge.
-     *
-     * @return The weight as double.
-     * @see Edge#setWeight
-     */
-    public Double getWeight() {
-      return weight;
-    }
+		public boolean hasGuard() {
+			return isNotNull(guard) && isNotNullOrEmpty(guard.getScript());
+		}
 
-    /**
-     * TODO Needs documentation
-     *
-     * @param visitor 
-     */
-    @Override
-    public void accept(ElementVisitor visitor) {
-      visitor.visit(this);
-    }
+		/**
+		 * Gets the weight of the edge.
+		 *
+		 * @return The weight as double.
+		 * @see Edge#setWeight
+		 */
+		public Double getWeight() {
+			return weight;
+		}
+		
+		public Double getDependency() {
+			return dependency;
+		}
 
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((guard == null) ? 0 : guard.hashCode());
-      result = prime * result
-        + ((sourceVertex == null) ? 0 : sourceVertex.hashCode());
-      result = prime * result
-        + ((targetVertex == null) ? 0 : targetVertex.hashCode());
-      result = prime * result
-        + ((weight == null) ? 0 : weight.hashCode());
-      return result;
-    }
+		/**
+		 * TODO Needs documentation
+		 *
+		 * @param visitor
+		 */
+		@Override
+		public void accept(ElementVisitor visitor) {
+			visitor.visit(this);
+		}
 
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (isNull(o) || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
-      RuntimeEdge that = (RuntimeEdge) o;
-      return Objects.equals(sourceVertex, that.sourceVertex) &&
-        Objects.equals(targetVertex, that.targetVertex) &&
-        Objects.equals(guard, that.guard) &&
-        Objects.equals(weight, that.weight);
-    }
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((guard == null) ? 0 : guard.hashCode());
+			result = prime * result + ((sourceVertex == null) ? 0 : sourceVertex.hashCode());
+			result = prime * result + ((targetVertex == null) ? 0 : targetVertex.hashCode());
+			result = prime * result + ((weight == null) ? 0 : weight.hashCode());
+			result = prime * result + ((dependency == null) ? 0 : dependency.hashCode());
+			return result;
+		}
 
+		@Override
+		public boolean equals(Object o) {
+			if (this == o)
+				return true;
+			if (isNull(o) || getClass() != o.getClass())
+				return false;
+			if (!super.equals(o))
+				return false;
+			RuntimeEdge that = (RuntimeEdge) o;
+			return Objects.equals(sourceVertex, that.sourceVertex) && Objects.equals(targetVertex, that.targetVertex)
+					&& Objects.equals(guard, that.guard) && Objects.equals(weight, that.weight) && Objects.equals(dependency, that.dependency);
+		}
 
-  }
+	}
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -39,304 +39,301 @@ import static org.graphwalker.core.common.Objects.unmodifiableList;
 import static org.graphwalker.core.model.Vertex.RuntimeVertex;
 
 /**
- * <h1>Edge</h1> The Edge holds the information for a transition in a model.
+ * <h1>Edge</h1>
+ * The  Edge holds the information for a transition in a model.
  * </p>
  * The edge represents an action performed by a test, which takes the system
- * under test, from a state to another. The edge has a source and target vertex.
- * If the vertices are identical, the edge is a self loop. The source vertex is
- * not mandatory, but in a model, there should be only one such instance. Also,
- * the target vertex is not mandatory, but again, in a model, there should be
- * only one such instance.
+ * under test, from a state to another.
+ * The edge has a source and target vertex. If the vertices are identical, the
+ * edge is a self loop. The source vertex is not mandatory, but in a model,
+ * there should be only one such instance. Also, the target vertex is not
+ * mandatory, but again, in a model, there should be only one such instance.
  *
  * @author Nils Olsson
  */
 public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
 
-	private Vertex sourceVertex;
-	private Vertex targetVertex;
-	private Guard guard;
-	private List<Action> actions = new ArrayList<>();
-	private Double weight = 0.0;
-	private Double dependency = 0.0;
+  private Vertex sourceVertex;
+  private Vertex targetVertex;
+  private Guard guard;
+  private List<Action> actions = new ArrayList<>();
+  private Double weight = 0.0;
+  private Double dependency = 0.0;
 
-	/**
-	 * Sets the source vertex of the edge.
-	 *
-	 * @param vertex
-	 *            The source vertex.
-	 * @return The edge.
-	 */
-	public Edge setSourceVertex(Vertex vertex) {
-		this.sourceVertex = vertex;
-		invalidateCache();
-		return this;
-	}
+  /**
+   * Sets the source vertex of the edge.
+   *
+   * @param vertex The source vertex.
+   * @return The edge.
+   */
+  public Edge setSourceVertex(Vertex vertex) {
+    this.sourceVertex = vertex;
+    invalidateCache();
+    return this;
+  }
 
-	/**
-	 * Gets the source vertex.
-	 *
-	 * @return The source vertex.
-	 * @see Edge#setSourceVertex
-	 */
-	public Vertex getSourceVertex() {
-		return sourceVertex;
-	}
+  /**
+   * Gets the source vertex.
+   *
+   * @return The source vertex.
+   * @see Edge#setSourceVertex
+   */
+  public Vertex getSourceVertex() {
+    return sourceVertex;
+  }
 
-	/**
-	 * Sets the target vertex of the edge.
-	 *
-	 * @param vertex
-	 *            The target vertex.
-	 * @return The edge.
-	 */
-	public Edge setTargetVertex(Vertex vertex) {
-		this.targetVertex = vertex;
-		invalidateCache();
-		return this;
-	}
+  /**
+   * Sets the target vertex of the edge.
+   *
+   * @param vertex The target vertex.
+   * @return The edge.
+   */
+  public Edge setTargetVertex(Vertex vertex) {
+    this.targetVertex = vertex;
+    invalidateCache();
+    return this;
+  }
 
-	/**
-	 * Gets the target vertex of the edge.
-	 *
-	 * @return The vertex.
-	 * @see Edge#setTargetVertex
-	 */
-	public Vertex getTargetVertex() {
-		return targetVertex;
-	}
+  /**
+   * Gets the target vertex of the edge.
+   *
+   * @return The vertex.
+   * @see Edge#setTargetVertex
+   */
+  public Vertex getTargetVertex() {
+    return targetVertex;
+  }
 
-	/**
-	 * Sets the guard of the edge. The code in the guard is by default
-	 * interpreted as javascript. The guard works like an 'if-statement'. It
-	 * controls the accessibility of the edge. During execution, the guard
-	 * evaluates to a boolean expression. If true, the edge is accessible, else
-	 * it's not.
-	 *
-	 * @param guard
-	 *            The guard.
-	 * @return The edge.
-	 */
-	public Edge setGuard(Guard guard) {
-		this.guard = guard;
-		invalidateCache();
-		return this;
-	}
+  /**
+   * Sets the guard of the edge. The code in the guard is by default interpreted as javascript.
+   * The guard works like an 'if-statement'. It controls the accessibility of the edge.
+   * During execution, the guard evaluates to a boolean expression.
+   * If true, the edge is accessible, else it's not.
+   *
+   * @param guard The guard.
+   * @return The edge.
+   */
+  public Edge setGuard(Guard guard) {
+    this.guard = guard;
+    invalidateCache();
+    return this;
+  }
 
-	/**
-	 * Gets the guard of the edge.
-	 *
-	 * @return The guard.
-	 * @see Edge#setGuard
-	 */
-	public Guard getGuard() {
-		return guard;
-	}
+  /**
+   * Gets the guard of the edge.
+   *
+   * @return The guard.
+   * @see Edge#setGuard
+   */
+  public Guard getGuard() {
+    return guard;
+  }
 
-	/**
-	 * Adds an action to the edge, which represents a piece of code that will be
-	 * executed each time the edge is being traversed. The code is by default
-	 * interpreted as javascript.
-	 *
-	 * @param action
-	 *            The action.
-	 * @return The edge.
-	 */
-	public Edge addAction(Action action) {
-		this.actions.add(action);
-		invalidateCache();
-		return this;
-	}
+  /**
+   * Adds an action to the edge, which represents a piece of code that will be executed
+   * each time the edge is being traversed. The code is by default interpreted as javascript.
+   *
+   * @param action The action.
+   * @return The edge.
+   */
+  public Edge addAction(Action action) {
+    this.actions.add(action);
+    invalidateCache();
+    return this;
+  }
 
-	public Edge addActions(Action... actions) {
-		return addActions(Arrays.asList(actions));
-	}
+  public Edge addActions(Action... actions) {
+    return addActions(Arrays.asList(actions));
+  }
 
-	public Edge addActions(List<Action> actions) {
-		this.actions.addAll(actions);
-		return this;
-	}
+  public Edge addActions(List<Action> actions) {
+    this.actions.addAll(actions);
+    return this;
+  }
 
-	/**
-	 * Adds a list of actions to the edge, which represents a pieces of code
-	 * that will be executed each time the edge is being traversed. The code
-	 * snippets is by default interpreted as javascript.
-	 *
-	 * @param actions
-	 *            The actions.
-	 * @return The edge.
-	 * @see Edge#addAction
-	 */
-	public Edge setActions(List<Action> actions) {
-		this.actions = new ArrayList<>(actions);
-		invalidateCache();
-		return this;
-	}
+  /**
+   * Adds a list of actions to the edge, which represents a pieces of code that will be executed
+   * each time the edge is being traversed. The code snippets is by default interpreted as javascript.
+   *
+   * @param actions The actions.
+   * @return The edge.
+   * @see Edge#addAction
+   */
+  public Edge setActions(List<Action> actions) {
+    this.actions = new ArrayList<>(actions);
+    invalidateCache();
+    return this;
+  }
 
-	/**
-	 * Gets the lists of actions of the edge.
-	 *
-	 * @return The actions
-	 * @see Edge#setActions
-	 */
-	public List<Action> getActions() {
-		return unmodifiableList(actions);
-	}
+  /**
+   * Gets the lists of actions of the edge.
+   *
+   * @return The actions
+   * @see Edge#setActions
+   */
+  public List<Action> getActions() {
+    return unmodifiableList(actions);
+  }
 
-	/**
-	 * Gets the weight of the edge.
-	 *
-	 * @return The weight as double.
-	 * @see Edge#setWeight
-	 */
-	public Double getWeight() {
-		return weight;
-	}
+  /**
+   * Gets the weight of the edge.
+   *
+   * @return The weight as double.
+   * @see Edge#setWeight
+   */
+  public Double getWeight() {
+    return weight;
+  }
 
-	/**
-	 * The weight is used as probability when using the
-	 * {@link org.graphwalker.core.generator.WeightedRandomPath}. Weight means
-	 * the probability for the edge to be selected.
-	 *
-	 * @param weight
-	 *            a double between 0 and 1
-	 * @return The edge
-	 */
-	public Edge setWeight(Double weight) {
-		this.weight = weight;
-		invalidateCache();
-		return this;
-	}
+  /**
+   * The weight is used as probability when using the {@link org.graphwalker.core.generator.WeightedRandomPath}.
+   * Weight means the probability for the edge to be selected.
+   *
+   * @param weight a double between 0 and 1
+   * @return The edge
+   */
+  public Edge setWeight(Double weight) {
+    this.weight = weight;
+    invalidateCache();
+    return this;
+  }
 
-	/**
-	 * Creates an immutable edge from this edge.
-	 *
-	 * @return An immutable edge as a RuntimeEdge
-	 */
-	@Override
-	protected RuntimeEdge createCache() {
-		return new RuntimeEdge(this);
-	}
+  /**
+   * Creates an immutable edge from this edge.
+   *
+   * @return An immutable edge as a RuntimeEdge
+   */
+  @Override
+  protected RuntimeEdge createCache() {
+    return new RuntimeEdge(this);
+  }
 
-	public Double getDependency() {
+  public Double getDependency() {
+	return dependency;
+}
+
+public Edge setDependency(Double dependency) {
+	this.dependency = dependency;
+	invalidateCache();
+	return this;
+}
+
+/**
+   * <h1>RuntimeEdge</h1>
+   * Immutable class for Edge
+   * </p>
+   * This class is used in models. It guarantees that that the internal states of
+   * the instance will not change after it's construction.
+   * </p>
+   */
+  public static final class RuntimeEdge extends RuntimeBase {
+
+    private final RuntimeVertex sourceVertex;
+    private final RuntimeVertex targetVertex;
+    private final Guard guard;
+    private final Double weight;
+    private final Double dependency;
+
+    private RuntimeEdge(Edge edge) {
+      super(edge.getId(), edge.getName(), edge.getActions(), edge.getRequirements(), edge.getProperties());
+      this.sourceVertex = build(edge.getSourceVertex());
+      this.targetVertex = build(edge.getTargetVertex());
+      this.guard = edge.getGuard();
+      this.weight = edge.getWeight();
+      this.dependency = edge.getDependency();
+    }
+
+    private <T> T build(Builder<T> builder) {
+      return isNotNull(builder) ? builder.build() : null;
+    }
+
+    /**
+     * Gets the source vertex.
+     *
+     * @return The source vertex.
+     * @see Edge#setSourceVertex
+     */
+    public RuntimeVertex getSourceVertex() {
+      return sourceVertex;
+    }
+
+    /**
+     * Gets the target vertex of the edge.
+     *
+     * @return The vertex.
+     * @see Edge#setTargetVertex
+     */
+    public RuntimeVertex getTargetVertex() {
+      return targetVertex;
+    }
+
+    /**
+     * Gets the guard of the edge.
+     *
+     * @return The guard.
+     * @see Edge#setGuard
+     */
+    public Guard getGuard() {
+      return guard;
+    }
+
+    public boolean hasGuard() {
+      return isNotNull(guard) && isNotNullOrEmpty(guard.getScript());
+    }
+
+    /**
+     * Gets the weight of the edge.
+     *
+     * @return The weight as double.
+     * @see Edge#setWeight
+     */
+    public Double getWeight() {
+      return weight;
+    }
+
+    /**
+     * TODO Needs documentation
+     *
+     * @param visitor 
+     */
+    @Override
+    public void accept(ElementVisitor visitor) {
+      visitor.visit(this);
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((guard == null) ? 0 : guard.hashCode());
+      result = prime * result
+        + ((sourceVertex == null) ? 0 : sourceVertex.hashCode());
+      result = prime * result
+        + ((targetVertex == null) ? 0 : targetVertex.hashCode());
+      result = prime * result
+        + ((weight == null) ? 0 : weight.hashCode());
+      result = prime * result
+    	        + ((dependency == null) ? 0 : dependency.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (isNull(o) || getClass() != o.getClass()) return false;
+      if (!super.equals(o)) return false;
+      RuntimeEdge that = (RuntimeEdge) o;
+      return Objects.equals(sourceVertex, that.sourceVertex) &&
+        Objects.equals(targetVertex, that.targetVertex) &&
+        Objects.equals(guard, that.guard) &&
+        Objects.equals(weight, that.weight) &&
+        Objects.equals(dependency, that.dependency);
+    }
+
+	public double getDependency() {
 		return dependency;
 	}
 
-	public Edge setDependency(Double dependency) {
-		this.dependency = dependency;
-		invalidateCache();
-		return this;
-	}
 
-	/**
-	 * <h1>RuntimeEdge</h1> Immutable class for Edge
-	 * </p>
-	 * This class is used in models. It guarantees that that the internal states
-	 * of the instance will not change after it's construction.
-	 * </p>
-	 */
-	public static final class RuntimeEdge extends RuntimeBase {
-
-		private final RuntimeVertex sourceVertex;
-		private final RuntimeVertex targetVertex;
-		private final Guard guard;
-		private final Double weight;
-        private final Double dependency;
-        
-		private RuntimeEdge(Edge edge) {
-			super(edge.getId(), edge.getName(), edge.getActions(), edge.getRequirements(), edge.getProperties());
-			this.sourceVertex = build(edge.getSourceVertex());
-			this.targetVertex = build(edge.getTargetVertex());
-			this.guard = edge.getGuard();
-			this.weight = edge.getWeight();
-			this.dependency = edge.getDependency();
-		}
-
-		private <T> T build(Builder<T> builder) {
-			return isNotNull(builder) ? builder.build() : null;
-		}
-
-		/**
-		 * Gets the source vertex.
-		 *
-		 * @return The source vertex.
-		 * @see Edge#setSourceVertex
-		 */
-		public RuntimeVertex getSourceVertex() {
-			return sourceVertex;
-		}
-
-		/**
-		 * Gets the target vertex of the edge.
-		 *
-		 * @return The vertex.
-		 * @see Edge#setTargetVertex
-		 */
-		public RuntimeVertex getTargetVertex() {
-			return targetVertex;
-		}
-
-		/**
-		 * Gets the guard of the edge.
-		 *
-		 * @return The guard.
-		 * @see Edge#setGuard
-		 */
-		public Guard getGuard() {
-			return guard;
-		}
-
-		public boolean hasGuard() {
-			return isNotNull(guard) && isNotNullOrEmpty(guard.getScript());
-		}
-
-		/**
-		 * Gets the weight of the edge.
-		 *
-		 * @return The weight as double.
-		 * @see Edge#setWeight
-		 */
-		public Double getWeight() {
-			return weight;
-		}
-		
-		public Double getDependency() {
-			return dependency;
-		}
-
-		/**
-		 * TODO Needs documentation
-		 *
-		 * @param visitor
-		 */
-		@Override
-		public void accept(ElementVisitor visitor) {
-			visitor.visit(this);
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result + ((guard == null) ? 0 : guard.hashCode());
-			result = prime * result + ((sourceVertex == null) ? 0 : sourceVertex.hashCode());
-			result = prime * result + ((targetVertex == null) ? 0 : targetVertex.hashCode());
-			result = prime * result + ((weight == null) ? 0 : weight.hashCode());
-			result = prime * result + ((dependency == null) ? 0 : dependency.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o)
-				return true;
-			if (isNull(o) || getClass() != o.getClass())
-				return false;
-			if (!super.equals(o))
-				return false;
-			RuntimeEdge that = (RuntimeEdge) o;
-			return Objects.equals(sourceVertex, that.sourceVertex) && Objects.equals(targetVertex, that.targetVertex)
-					&& Objects.equals(guard, that.guard) && Objects.equals(weight, that.weight) && Objects.equals(dependency, that.dependency);
-		}
-
-	}
+  }
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -58,7 +58,7 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
   private Guard guard;
   private List<Action> actions = new ArrayList<>();
   private Double weight = 0.0;
-  private Double dependency = 0.0;
+  private Integer dependency = 0;
 
   /**
    * Sets the source vertex of the edge.
@@ -214,7 +214,7 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
    * @return The dependency as double.
    * @see Edge#setDependenct
    */
-  public Double getDependency() {
+  public Integer getDependency() {
 	return dependency;
   }
 
@@ -226,12 +226,8 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
    * @param dependency a double between 0 and 1
    * @return The edge
    */
-  public Edge setDependency(Double dependency) {
-	if (dependency > 1 && dependency <= 100) {
-		this.dependency = dependency / 100;
-	} else {
-		this.dependency = dependency;
-	}
+  public Edge setDependency(Integer dependency) {
+	this.dependency = dependency;
 	invalidateCache();
 	return this;
   }
@@ -250,7 +246,7 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
     private final RuntimeVertex targetVertex;
     private final Guard guard;
     private final Double weight;
-    private final Double dependency;
+    private final Integer dependency;
 
     private RuntimeEdge(Edge edge) {
       super(edge.getId(), edge.getName(), edge.getActions(), edge.getRequirements(), edge.getProperties());
@@ -351,11 +347,21 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
     /**
      * Gets the dependency of the edge.
      *
-     * @return The dependency as double.
+     * @return The dependency as Integer.
      * @see Edge#setDependency
      */
-	public double getDependency() {
+	public Integer getDependency() {
 		return dependency;
+	}
+	
+	 /**
+     * Gets the dependency of the edge.
+     *
+     * @return The dependency as Double.
+     * @see Edge#setDependency
+     */
+	public double getDependencyAsDouble() {
+		return (double)getDependency() / 100;
 	}
 
 

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -227,7 +227,11 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
    * @return The edge
    */
   public Edge setDependency(Double dependency) {
-	this.dependency = dependency;
+	if (dependency > 1 && dependency <= 100) {
+		this.dependency = dependency / 100;
+	} else {
+		this.dependency = dependency;
+	}
 	invalidateCache();
 	return this;
   }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/model/Edge.java
@@ -208,15 +208,29 @@ public final class Edge extends CachedBuilder<Edge, Edge.RuntimeEdge> {
     return new RuntimeEdge(this);
   }
 
+  /**
+   * Gets the dependency of the edge.
+   *
+   * @return The dependency as double.
+   * @see Edge#setDependenct
+   */
   public Double getDependency() {
 	return dependency;
-}
+  }
 
-public Edge setDependency(Double dependency) {
+  /**
+   * The dependency shows how much targetVertex depends on sourceVertex.
+   * One way to obtain the dependency is by using
+   *  process mining to generate a model out of log files.
+   *
+   * @param dependency a double between 0 and 1
+   * @return The edge
+   */
+  public Edge setDependency(Double dependency) {
 	this.dependency = dependency;
 	invalidateCache();
 	return this;
-}
+  }
 
 /**
    * <h1>RuntimeEdge</h1>
@@ -330,6 +344,12 @@ public Edge setDependency(Double dependency) {
         Objects.equals(dependency, that.dependency);
     }
 
+    /**
+     * Gets the dependency of the edge.
+     *
+     * @return The dependency as double.
+     * @see Edge#setDependency
+     */
 	public double getDependency() {
 		return dependency;
 	}

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -60,8 +60,8 @@ public class DependencyEdgeCoverageTest {
   public void testFulfilmentOneEdgeBelowDependency() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(90);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(80);
     Model model = new Model().addEdge(e1).addEdge(e2);
     StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
@@ -81,8 +81,8 @@ public class DependencyEdgeCoverageTest {
   public void testFulfilment() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(90);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(80);
     Model model = new Model().addEdge(e1).addEdge(e2);
     StopCondition condition = new DependencyEdgeCoverage(75);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
@@ -102,8 +102,8 @@ public class DependencyEdgeCoverageTest {
   public void testIsFulfilled() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(90);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(80);
     Model model = new Model().addEdge(e2).addEdge(e1);
     StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
@@ -127,8 +127,8 @@ public class DependencyEdgeCoverageTest {
   public void testIsFulfilledHighDependencyTreshold() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.8);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(80);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(80);
     Model model = new Model().addEdge(e2).addEdge(e1);
     StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
@@ -152,8 +152,8 @@ public class DependencyEdgeCoverageTest {
   public void testIsFulfilledDependencyTreshold() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(90);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(80);
     Model model = new Model().addEdge(e2).addEdge(e1);
     StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -1,0 +1,110 @@
+package org.graphwalker.core.condition;
+
+/*
+ * #%L
+ * GraphWalker Core
+ * %%
+ * Copyright (C) 2005 - 2014 GraphWalker
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import org.graphwalker.core.generator.RandomPath;
+import org.graphwalker.core.machine.Context;
+import org.graphwalker.core.machine.TestExecutionContext;
+import org.graphwalker.core.model.Edge;
+import org.graphwalker.core.model.Model;
+import org.graphwalker.core.model.Vertex;
+import org.graphwalker.core.statistics.Profiler;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Miroslav Janeski
+ */
+public class DependencyEdgeCoverageTest {
+
+  @Test
+  public void testConstructor() {
+    DependencyEdgeCoverage edgeCoverage = new DependencyEdgeCoverage(200,100);
+    assertThat(edgeCoverage.getPercent(), is(200));
+    assertThat(edgeCoverage.getDependency(), is(100));
+  }
+
+  @Test(expected = StopConditionException.class)
+  public void testNegativePercent() {
+    new DependencyEdgeCoverage(-55,1);
+  }
+  
+  @Test(expected = StopConditionException.class)
+  public void testNegativeDependency() {
+    new DependencyEdgeCoverage(1,-55);
+  }
+
+  @Test
+  public void testFulfilment() {
+    Vertex v1 = new Vertex();
+    Vertex v2 = new Vertex();
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.8);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.9);
+    Model model = new Model().addEdge(e1).addEdge(e2);
+    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    Context context = new TestExecutionContext(model, new RandomPath(condition));
+    context.setProfiler(new Profiler());
+    assertThat(condition.getFulfilment(), is(0.0));
+    context.setCurrentElement(e1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertThat(condition.getFulfilment(), is(0.0));
+    context.setCurrentElement(e2.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertThat(condition.getFulfilment(), is(1.0));
+  }
+
+  @Test
+  public void testIsFulfilled() {
+    Vertex v1 = new Vertex();
+    Vertex v2 = new Vertex();
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Model model = new Model().addEdge(e2).addEdge(e1);
+    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    Context context = new TestExecutionContext(model, new RandomPath(condition));
+    context.setProfiler(new Profiler());
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e2.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(v1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertTrue(condition.isFulfilled());
+  }
+}

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -47,19 +47,13 @@ public class DependencyEdgeCoverageTest {
 
   @Test
   public void testConstructor() {
-    DependencyEdgeCoverage edgeCoverage = new DependencyEdgeCoverage(200,100);
-    assertThat(edgeCoverage.getPercent(), is(200));
+    DependencyEdgeCoverage edgeCoverage = new DependencyEdgeCoverage(100);
     assertThat(edgeCoverage.getDependency(), is(100));
-  }
-
-  @Test(expected = StopConditionException.class)
-  public void testNegativePercent() {
-    new DependencyEdgeCoverage(-55,1);
   }
   
   @Test(expected = StopConditionException.class)
   public void testNegativeDependency() {
-    new DependencyEdgeCoverage(1,-55);
+    new DependencyEdgeCoverage(-55);
   }
 
   @Test
@@ -69,7 +63,7 @@ public class DependencyEdgeCoverageTest {
     Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
     Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
     Model model = new Model().addEdge(e1).addEdge(e2);
-    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
     context.setProfiler(new Profiler());
     assertThat(condition.getFulfilment(), is(0.0));
@@ -90,7 +84,7 @@ public class DependencyEdgeCoverageTest {
     Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
     Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
     Model model = new Model().addEdge(e2).addEdge(e1);
-    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
     context.setProfiler(new Profiler());
     assertFalse(condition.isFulfilled());
@@ -115,7 +109,7 @@ public class DependencyEdgeCoverageTest {
     Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.8);
     Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
     Model model = new Model().addEdge(e2).addEdge(e1);
-    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    StopCondition condition = new DependencyEdgeCoverage(85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
     context.setProfiler(new Profiler());
     assertFalse(condition.isFulfilled());
@@ -130,6 +124,6 @@ public class DependencyEdgeCoverageTest {
     context.setCurrentElement(v1.build());
     context.getProfiler().start(context);
     context.getProfiler().stop(context);
-    assertTrue(condition.isFulfilled());
+    assertFalse(condition.isFulfilled());
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -57,7 +57,7 @@ public class DependencyEdgeCoverageTest {
   }
 
   @Test
-  public void testFulfilment() {
+  public void testFulfilmentOneEdgeBelowDependency() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
     Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
@@ -77,6 +77,27 @@ public class DependencyEdgeCoverageTest {
     assertThat(condition.getFulfilment(), is(1.0));
   }
 
+  @Test
+  public void testFulfilment() {
+    Vertex v1 = new Vertex();
+    Vertex v2 = new Vertex();
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Model model = new Model().addEdge(e1).addEdge(e2);
+    StopCondition condition = new DependencyEdgeCoverage(75);
+    Context context = new TestExecutionContext(model, new RandomPath(condition));
+    context.setProfiler(new Profiler());
+    assertThat(condition.getFulfilment(), is(0.0));
+    context.setCurrentElement(e1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertThat(condition.getFulfilment(), is(0.5));
+    context.setCurrentElement(e2.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertThat(condition.getFulfilment(), is(1.0));
+  }
+  
   @Test
   public void testIsFulfilled() {
     Vertex v1 = new Vertex();

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -107,4 +107,29 @@ public class DependencyEdgeCoverageTest {
     context.getProfiler().stop(context);
     assertTrue(condition.isFulfilled());
   }
+  
+  @Test
+  public void testIsFulfilledHighDependencyTreshold() {
+    Vertex v1 = new Vertex();
+    Vertex v2 = new Vertex();
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.8);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Model model = new Model().addEdge(e2).addEdge(e1);
+    StopCondition condition = new DependencyEdgeCoverage(100,85);
+    Context context = new TestExecutionContext(model, new RandomPath(condition));
+    context.setProfiler(new Profiler());
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e2.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(v1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertTrue(condition.isFulfilled());
+  }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -147,4 +147,30 @@ public class DependencyEdgeCoverageTest {
     context.getProfiler().stop(context);
     assertFalse(condition.isFulfilled());
   }
+  
+  @Test
+  public void testIsFulfilledDependencyTreshold() {
+    Vertex v1 = new Vertex();
+    Vertex v2 = new Vertex();
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
+    Model model = new Model().addEdge(e2).addEdge(e1);
+    StopCondition condition = new DependencyEdgeCoverage(85);
+    Context context = new TestExecutionContext(model, new RandomPath(condition));
+    context.setProfiler(new Profiler());
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(e2.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertFalse(condition.isFulfilled());
+    context.setCurrentElement(v1.build());
+    context.getProfiler().start(context);
+    context.getProfiler().stop(context);
+    assertTrue(condition.isFulfilled());
+  }
+
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/condition/DependencyEdgeCoverageTest.java
@@ -66,8 +66,8 @@ public class DependencyEdgeCoverageTest {
   public void testFulfilment() {
     Vertex v1 = new Vertex();
     Vertex v2 = new Vertex();
-    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.8);
-    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.9);
+    Edge e1 = new Edge().setSourceVertex(v1).setTargetVertex(v2).setDependency(0.9);
+    Edge e2 = new Edge().setSourceVertex(v2).setTargetVertex(v1).setDependency(0.8);
     Model model = new Model().addEdge(e1).addEdge(e2);
     StopCondition condition = new DependencyEdgeCoverage(100,85);
     Context context = new TestExecutionContext(model, new RandomPath(condition));
@@ -76,7 +76,7 @@ public class DependencyEdgeCoverageTest {
     context.setCurrentElement(e1.build());
     context.getProfiler().start(context);
     context.getProfiler().stop(context);
-    assertThat(condition.getFulfilment(), is(0.0));
+    assertThat(condition.getFulfilment(), is(1.0));
     context.setCurrentElement(e2.build());
     context.getProfiler().start(context);
     context.getProfiler().stop(context);

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
@@ -64,7 +64,7 @@ public class GeneratorLoader extends Generator_ParserBaseListener {
 			stopConditions.add(new EdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
 		} else if (ctx.getChild(0).getText().equalsIgnoreCase("dependency_edge_coverage")
 				|| ctx.getChild(0).getText().equalsIgnoreCase("dependencyedgecoverage")) {
-			stopConditions.add(new DependencyEdgeCoverage(100,Integer.parseInt(ctx.getChild(2).getText())));
+			stopConditions.add(new DependencyEdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
 		} else if (ctx.getChild(0).getText().equalsIgnoreCase("vertex_coverage")
 				|| ctx.getChild(0).getText().equalsIgnoreCase("vertexcoverage")) {
 			stopConditions.add(new VertexCoverage(Integer.parseInt(ctx.getChild(2).getText())));

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
@@ -26,7 +26,6 @@ package org.graphwalker.dsl.antlr.generator;
  * #L%
  */
 
-
 import org.antlr.v4.runtime.misc.NotNull;
 import org.graphwalker.core.condition.*;
 import org.graphwalker.core.generator.*;
@@ -41,89 +40,92 @@ import java.util.concurrent.TimeUnit;
  */
 public class GeneratorLoader extends Generator_ParserBaseListener {
 
-  StopCondition stopCondition = null;
-  ArrayList<PathGenerator> pathGenerators = new ArrayList<>();
-  ArrayList<StopCondition> stopConditions = new ArrayList<>();
+	StopCondition stopCondition = null;
+	ArrayList<PathGenerator> pathGenerators = new ArrayList<>();
+	ArrayList<StopCondition> stopConditions = new ArrayList<>();
 
-  @Override
-  public void exitBooleanAndExpression(@NotNull Generator_Parser.BooleanAndExpressionContext ctx) {
-    if (ctx.AND().size() > 0) {
-      CombinedCondition combinedCondition = new CombinedCondition();
-      combinedCondition.addStopCondition(stopConditions.get(0));
-      combinedCondition.addStopCondition(stopConditions.get(1));
-      stopCondition = combinedCondition;
-    }
-  }
+	@Override
+	public void exitBooleanAndExpression(@NotNull Generator_Parser.BooleanAndExpressionContext ctx) {
+		if (ctx.AND().size() > 0) {
+			CombinedCondition combinedCondition = new CombinedCondition();
+			combinedCondition.addStopCondition(stopConditions.get(0));
+			combinedCondition.addStopCondition(stopConditions.get(1));
+			stopCondition = combinedCondition;
+		}
+	}
 
-  @Override
-  public void exitStopCondition(@NotNull Generator_Parser.StopConditionContext ctx) {
+	@Override
+	public void exitStopCondition(@NotNull Generator_Parser.StopConditionContext ctx) {
 
-    if (ctx.getChild(0).getText().equalsIgnoreCase("never")) {
-      stopConditions.add(new Never());
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("edge_coverage") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("edgecoverage")) {
-      stopConditions.add(new EdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("vertex_coverage") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("vertexcoverage")) {
-      stopConditions.add(new VertexCoverage(Integer.parseInt(ctx.getChild(2).getText())));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_vertex") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("reachedvertex")) {
-      stopConditions.add(new ReachedVertex(ctx.getChild(2).getText()));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_edge") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("reachededge")) {
-      stopConditions.add(new ReachedEdge(ctx.getChild(2).getText()));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("time_duration") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("timeduration")) {
-      stopConditions.add(new TimeDuration(Long.parseLong(ctx.getChild(2).getText()), TimeUnit.SECONDS));
-    }
-  }
+		if (ctx.getChild(0).getText().equalsIgnoreCase("never")) {
+			stopConditions.add(new Never());
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("edge_coverage")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("edgecoverage")) {
+			stopConditions.add(new EdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("dependency_edge_coverage")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("dependencyedgecoverage")) {
+			stopConditions.add(new DependencyEdgeCoverage(100,Integer.parseInt(ctx.getChild(2).getText())));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("vertex_coverage")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("vertexcoverage")) {
+			stopConditions.add(new VertexCoverage(Integer.parseInt(ctx.getChild(2).getText())));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_vertex")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("reachedvertex")) {
+			stopConditions.add(new ReachedVertex(ctx.getChild(2).getText()));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_edge")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("reachededge")) {
+			stopConditions.add(new ReachedEdge(ctx.getChild(2).getText()));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("time_duration")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("timeduration")) {
+			stopConditions.add(new TimeDuration(Long.parseLong(ctx.getChild(2).getText()), TimeUnit.SECONDS));
+		}
+	}
 
-  @Override
-  public void exitLogicalExpression(@NotNull Generator_Parser.LogicalExpressionContext ctx) {
-    if (ctx.OR().size() > 0) {
-      AlternativeCondition alternativeCondition = new AlternativeCondition();
-      alternativeCondition.addStopCondition(stopConditions.get(0));
-      alternativeCondition.addStopCondition(stopConditions.get(1));
-      stopCondition = alternativeCondition;
-    }
-  }
+	@Override
+	public void exitLogicalExpression(@NotNull Generator_Parser.LogicalExpressionContext ctx) {
+		if (ctx.OR().size() > 0) {
+			AlternativeCondition alternativeCondition = new AlternativeCondition();
+			alternativeCondition.addStopCondition(stopConditions.get(0));
+			alternativeCondition.addStopCondition(stopConditions.get(1));
+			stopCondition = alternativeCondition;
+		}
+	}
 
-  @Override
-  public void exitGenerator(@NotNull Generator_Parser.GeneratorContext ctx) {
-    if (stopConditions.size() == 1) {
-      stopCondition = stopConditions.get(0);
-    }
+	@Override
+	public void exitGenerator(@NotNull Generator_Parser.GeneratorContext ctx) {
+		if (stopConditions.size() == 1) {
+			stopCondition = stopConditions.get(0);
+		}
 
-    if (ctx.getChild(0).getText().equalsIgnoreCase("random") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("randompath")) {
-      pathGenerators.add(new RandomPath(stopCondition));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("weighted_random") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("weightedrandompath")) {
-      pathGenerators.add(new WeightedRandomPath(stopCondition));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("quick_random") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("quickrandompath")) {
-      pathGenerators.add(new QuickRandomPath(stopCondition));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("a_star") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("astartpath")) {
-      pathGenerators.add(new AStarPath((ReachedStopCondition) stopCondition));
-    } else if (ctx.getChild(0).getText().equalsIgnoreCase("shortest_all_paths") ||
-      ctx.getChild(0).getText().equalsIgnoreCase("shortestallpaths")) {
-      pathGenerators.add(new ShortestAllPaths(stopCondition));
-    }
-    stopConditions.clear();
-  }
+		if (ctx.getChild(0).getText().equalsIgnoreCase("random")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("randompath")) {
+			pathGenerators.add(new RandomPath(stopCondition));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("weighted_random")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("weightedrandompath")) {
+			pathGenerators.add(new WeightedRandomPath(stopCondition));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("quick_random")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("quickrandompath")) {
+			pathGenerators.add(new QuickRandomPath(stopCondition));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("a_star")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("astartpath")) {
+			pathGenerators.add(new AStarPath((ReachedStopCondition) stopCondition));
+		} else if (ctx.getChild(0).getText().equalsIgnoreCase("shortest_all_paths")
+				|| ctx.getChild(0).getText().equalsIgnoreCase("shortestallpaths")) {
+			pathGenerators.add(new ShortestAllPaths(stopCondition));
+		}
+		stopConditions.clear();
+	}
 
-  public PathGenerator getGenerator() {
-    if (pathGenerators.isEmpty()) {
-      return null;
-    } else if (pathGenerators.size() == 1) {
-      return pathGenerators.get(0);
-    }
+	public PathGenerator getGenerator() {
+		if (pathGenerators.isEmpty()) {
+			return null;
+		} else if (pathGenerators.size() == 1) {
+			return pathGenerators.get(0);
+		}
 
-    CombinedPath combinedPath = new CombinedPath();
-    for (PathGenerator pathGenerator : pathGenerators) {
-      combinedPath.addPathGenerator(pathGenerator);
-    }
-    return combinedPath;
-  }
+		CombinedPath combinedPath = new CombinedPath();
+		for (PathGenerator pathGenerator : pathGenerators) {
+			combinedPath.addPathGenerator(pathGenerator);
+		}
+		return combinedPath;
+	}
 }

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
@@ -26,6 +26,7 @@ package org.graphwalker.dsl.antlr.generator;
  * #L%
  */
 
+
 import org.antlr.v4.runtime.misc.NotNull;
 import org.graphwalker.core.condition.*;
 import org.graphwalker.core.generator.*;
@@ -40,92 +41,92 @@ import java.util.concurrent.TimeUnit;
  */
 public class GeneratorLoader extends Generator_ParserBaseListener {
 
-	StopCondition stopCondition = null;
-	ArrayList<PathGenerator> pathGenerators = new ArrayList<>();
-	ArrayList<StopCondition> stopConditions = new ArrayList<>();
+  StopCondition stopCondition = null;
+  ArrayList<PathGenerator> pathGenerators = new ArrayList<>();
+  ArrayList<StopCondition> stopConditions = new ArrayList<>();
 
-	@Override
-	public void exitBooleanAndExpression(@NotNull Generator_Parser.BooleanAndExpressionContext ctx) {
-		if (ctx.AND().size() > 0) {
-			CombinedCondition combinedCondition = new CombinedCondition();
-			combinedCondition.addStopCondition(stopConditions.get(0));
-			combinedCondition.addStopCondition(stopConditions.get(1));
-			stopCondition = combinedCondition;
-		}
-	}
+  @Override
+  public void exitBooleanAndExpression(@NotNull Generator_Parser.BooleanAndExpressionContext ctx) {
+    if (ctx.AND().size() > 0) {
+      CombinedCondition combinedCondition = new CombinedCondition();
+      combinedCondition.addStopCondition(stopConditions.get(0));
+      combinedCondition.addStopCondition(stopConditions.get(1));
+      stopCondition = combinedCondition;
+    }
+  }
 
-	@Override
-	public void exitStopCondition(@NotNull Generator_Parser.StopConditionContext ctx) {
+  @Override
+  public void exitStopCondition(@NotNull Generator_Parser.StopConditionContext ctx) {
 
-		if (ctx.getChild(0).getText().equalsIgnoreCase("never")) {
-			stopConditions.add(new Never());
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("edge_coverage")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("edgecoverage")) {
-			stopConditions.add(new EdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("dependency_edge_coverage")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("dependencyedgecoverage")) {
-			stopConditions.add(new DependencyEdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("vertex_coverage")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("vertexcoverage")) {
-			stopConditions.add(new VertexCoverage(Integer.parseInt(ctx.getChild(2).getText())));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_vertex")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("reachedvertex")) {
-			stopConditions.add(new ReachedVertex(ctx.getChild(2).getText()));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_edge")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("reachededge")) {
-			stopConditions.add(new ReachedEdge(ctx.getChild(2).getText()));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("time_duration")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("timeduration")) {
-			stopConditions.add(new TimeDuration(Long.parseLong(ctx.getChild(2).getText()), TimeUnit.SECONDS));
-		}
-	}
+    if (ctx.getChild(0).getText().equalsIgnoreCase("never")) {
+      stopConditions.add(new Never());
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("edge_coverage") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("edgecoverage")) {
+      stopConditions.add(new EdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("vertex_coverage") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("vertexcoverage")) {
+      stopConditions.add(new VertexCoverage(Integer.parseInt(ctx.getChild(2).getText())));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_vertex") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("reachedvertex")) {
+      stopConditions.add(new ReachedVertex(ctx.getChild(2).getText()));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("reached_edge") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("reachededge")) {
+      stopConditions.add(new ReachedEdge(ctx.getChild(2).getText()));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("time_duration") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("timeduration")) {
+      stopConditions.add(new TimeDuration(Long.parseLong(ctx.getChild(2).getText()), TimeUnit.SECONDS));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("dependency_edge_coverage") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("dependencyedgecoverage")) {
+      stopConditions.add(new DependencyEdgeCoverage(Integer.parseInt(ctx.getChild(2).getText())));
+    }
+  }
 
-	@Override
-	public void exitLogicalExpression(@NotNull Generator_Parser.LogicalExpressionContext ctx) {
-		if (ctx.OR().size() > 0) {
-			AlternativeCondition alternativeCondition = new AlternativeCondition();
-			alternativeCondition.addStopCondition(stopConditions.get(0));
-			alternativeCondition.addStopCondition(stopConditions.get(1));
-			stopCondition = alternativeCondition;
-		}
-	}
+  @Override
+  public void exitLogicalExpression(@NotNull Generator_Parser.LogicalExpressionContext ctx) {
+    if (ctx.OR().size() > 0) {
+      AlternativeCondition alternativeCondition = new AlternativeCondition();
+      alternativeCondition.addStopCondition(stopConditions.get(0));
+      alternativeCondition.addStopCondition(stopConditions.get(1));
+      stopCondition = alternativeCondition;
+    }
+  }
 
-	@Override
-	public void exitGenerator(@NotNull Generator_Parser.GeneratorContext ctx) {
-		if (stopConditions.size() == 1) {
-			stopCondition = stopConditions.get(0);
-		}
+  @Override
+  public void exitGenerator(@NotNull Generator_Parser.GeneratorContext ctx) {
+    if (stopConditions.size() == 1) {
+      stopCondition = stopConditions.get(0);
+    }
 
-		if (ctx.getChild(0).getText().equalsIgnoreCase("random")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("randompath")) {
-			pathGenerators.add(new RandomPath(stopCondition));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("weighted_random")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("weightedrandompath")) {
-			pathGenerators.add(new WeightedRandomPath(stopCondition));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("quick_random")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("quickrandompath")) {
-			pathGenerators.add(new QuickRandomPath(stopCondition));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("a_star")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("astartpath")) {
-			pathGenerators.add(new AStarPath((ReachedStopCondition) stopCondition));
-		} else if (ctx.getChild(0).getText().equalsIgnoreCase("shortest_all_paths")
-				|| ctx.getChild(0).getText().equalsIgnoreCase("shortestallpaths")) {
-			pathGenerators.add(new ShortestAllPaths(stopCondition));
-		}
-		stopConditions.clear();
-	}
+    if (ctx.getChild(0).getText().equalsIgnoreCase("random") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("randompath")) {
+      pathGenerators.add(new RandomPath(stopCondition));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("weighted_random") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("weightedrandompath")) {
+      pathGenerators.add(new WeightedRandomPath(stopCondition));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("quick_random") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("quickrandompath")) {
+      pathGenerators.add(new QuickRandomPath(stopCondition));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("a_star") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("astartpath")) {
+      pathGenerators.add(new AStarPath((ReachedStopCondition) stopCondition));
+    } else if (ctx.getChild(0).getText().equalsIgnoreCase("shortest_all_paths") ||
+      ctx.getChild(0).getText().equalsIgnoreCase("shortestallpaths")) {
+      pathGenerators.add(new ShortestAllPaths(stopCondition));
+    }
+    stopConditions.clear();
+  }
 
-	public PathGenerator getGenerator() {
-		if (pathGenerators.isEmpty()) {
-			return null;
-		} else if (pathGenerators.size() == 1) {
-			return pathGenerators.get(0);
-		}
+  public PathGenerator getGenerator() {
+    if (pathGenerators.isEmpty()) {
+      return null;
+    } else if (pathGenerators.size() == 1) {
+      return pathGenerators.get(0);
+    }
 
-		CombinedPath combinedPath = new CombinedPath();
-		for (PathGenerator pathGenerator : pathGenerators) {
-			combinedPath.addPathGenerator(pathGenerator);
-		}
-		return combinedPath;
-	}
+    CombinedPath combinedPath = new CombinedPath();
+    for (PathGenerator pathGenerator : pathGenerators) {
+      combinedPath.addPathGenerator(pathGenerator);
+    }
+    return combinedPath;
+  }
 }

--- a/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
+++ b/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
@@ -156,4 +156,12 @@ public class GeneratorFactoryTest {
     Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
     Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
+  
+  @Test // Single stop condition
+  public void test13() {
+	    PathGenerator generator = GeneratorFactory.parse("random(dependency_edge_coverage(80))");
+	    Assert.assertThat(generator, instanceOf(RandomPath.class));
+	    Assert.assertThat(generator.getStopCondition(), instanceOf(DependencyEdgeCoverage.class));
+	    Assert.assertThat(((DependencyEdgeCoverage) generator.getStopCondition()).getDependency(), is(80));
+	  }
 }

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/json/JsonEdge.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/json/JsonEdge.java
@@ -47,7 +47,7 @@ public class JsonEdge {
   private List<String> actions;
   private List<String> requirements;
   private Map<String, Object> properties;
-  private double dependency;
+  private Integer dependency;
   private String sourceVertexId;
   private String targetVertexId;
 

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/json/JsonEdge.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/json/JsonEdge.java
@@ -47,6 +47,7 @@ public class JsonEdge {
   private List<String> actions;
   private List<String> requirements;
   private Map<String, Object> properties;
+  private double dependency;
   private String sourceVertexId;
   private String targetVertexId;
 
@@ -62,6 +63,7 @@ public class JsonEdge {
     Edge edge = new Edge();
     edge.setId(id);
     edge.setName(name);
+    edge.setDependency(dependency);
     edge.setGuard(new Guard(guard));
 
     if (actions != null) {
@@ -86,6 +88,7 @@ public class JsonEdge {
   public void setEdge(Edge.RuntimeEdge edge) {
     id = edge.getId();
     name = edge.getName();
+    dependency = edge.getDependency();
     if (edge.hasGuard()) {
       guard = edge.getGuard().getScript();
     }
@@ -130,6 +133,8 @@ public class JsonEdge {
       edge.setName(name);
     }
 
+    edge.setDependency(dependency);
+    
     if (guard != null) {
       edge.setGuard(new Guard(guard));
     }

--- a/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
+++ b/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
@@ -248,15 +248,15 @@ public class JsonContextFactoryTest {
 	    Assert.assertThat(context.getModel().getEdges().size(), is(4));
 
 	    Edge.RuntimeEdge e = (Edge.RuntimeEdge)context.getModel().getElementById("e0");
-	    Assert.assertThat(e.getDependency(), is(100d));
+	    Assert.assertThat(e.getDependency(), is(1d));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e1");
-	    Assert.assertThat(e.getDependency(), is(100d));
+	    Assert.assertThat(e.getDependency(), is(1d));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e2");
-	    Assert.assertThat(e.getDependency(), is(85d));
+	    Assert.assertThat(e.getDependency(), is(0.85d));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e3");
-	    Assert.assertThat(e.getDependency(), is(15d));
+	    Assert.assertThat(e.getDependency(), is(0.15d));
   }
 }

--- a/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
+++ b/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
@@ -248,15 +248,15 @@ public class JsonContextFactoryTest {
 	    Assert.assertThat(context.getModel().getEdges().size(), is(4));
 
 	    Edge.RuntimeEdge e = (Edge.RuntimeEdge)context.getModel().getElementById("e0");
-	    Assert.assertThat(e.getDependency(), is(1d));
+	    Assert.assertThat(e.getDependency(), is(100));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e1");
-	    Assert.assertThat(e.getDependency(), is(1d));
+	    Assert.assertThat(e.getDependency(), is(100));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e2");
-	    Assert.assertThat(e.getDependency(), is(0.85d));
+	    Assert.assertThat(e.getDependency(), is(85));
 
 	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e3");
-	    Assert.assertThat(e.getDependency(), is(0.15d));
+	    Assert.assertThat(e.getDependency(), is(15));
   }
 }

--- a/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
+++ b/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
@@ -237,8 +237,26 @@ public class JsonContextFactoryTest {
   }
   
   @Test
-  public void acceptDependencyJsonTest() {
-    ContextFactory factory = new JsonContextFactory();
-    Assert.assertTrue(factory.accept(Paths.get("json/DependencyModel.json")));
+  public void acceptDependencyJsonTest() throws IOException {
+	    List<Context> contexts = new JsonContextFactory().create(Paths.get("json/DependencyModel.json"));
+	    Assert.assertNotNull(contexts);
+	    Assert.assertThat(contexts.size(), is(1));
+
+	    Context context = contexts.get(0);
+
+	    Assert.assertThat(context.getModel().getVertices().size(), is(2));
+	    Assert.assertThat(context.getModel().getEdges().size(), is(4));
+
+	    Edge.RuntimeEdge e = (Edge.RuntimeEdge)context.getModel().getElementById("e0");
+	    Assert.assertThat(e.getDependency(), is(100d));
+
+	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e1");
+	    Assert.assertThat(e.getDependency(), is(100d));
+
+	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e2");
+	    Assert.assertThat(e.getDependency(), is(85d));
+
+	    e = (Edge.RuntimeEdge)context.getModel().getElementById("e3");
+	    Assert.assertThat(e.getDependency(), is(15d));
   }
 }

--- a/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
+++ b/graphwalker-io/src/test/java/org/graphwalker/io/factory/json/JsonContextFactoryTest.java
@@ -235,4 +235,10 @@ public class JsonContextFactoryTest {
       logger.debug(e.getName());
     }
   }
+  
+  @Test
+  public void acceptDependencyJsonTest() {
+    ContextFactory factory = new JsonContextFactory();
+    Assert.assertTrue(factory.accept(Paths.get("json/DependencyModel.json")));
+  }
 }

--- a/graphwalker-io/src/test/resources/json/DependencyModel.json
+++ b/graphwalker-io/src/test/resources/json/DependencyModel.json
@@ -1,0 +1,48 @@
+{
+  "models": [
+    {
+      "name": "Dependency model",
+      "generator": "random(dependency_edge_coverage(80))",
+      "startElementId": "e0",
+      "vertices": [
+        {
+          "name": "v_VerifySomeAction",
+          "id": "n0"
+        },
+        {
+          "name": "v_VerifySomeOtherAction",
+          "id": "n1"
+        }
+      ],
+      "edges": [
+        {
+          "name": "e_FirstAction",
+          "id": "e0",
+          "targetVertexId": "n0",
+          "dependency": "100"
+        },
+        {
+          "name": "e_AnotherAction",
+          "id": "e1",
+          "sourceVertexId": "n0",
+          "targetVertexId": "n1",
+          "dependency": "100"
+        },
+        {
+          "name": "e_SomeOtherAction",
+          "id": "e2",
+          "sourceVertexId": "n1",
+          "targetVertexId": "n1",
+          "dependency": "85"
+        },
+        {
+          "name": "e_SomeOtherAction",
+          "id": "e3",
+          "sourceVertexId": "n1",
+          "targetVertexId": "n0",
+          "dependency": "15"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The **Dependency Stop Condition** is a special case of the current stop condition. The Dependency Stop Condition checks for number of completed edges that have higher dependency than the threshold dependency. However, if there are no edges with dependency higher than the threshold, then the Dependency Stop Condition behaves the same as the current Stop Condition i.e. it ignores the dependency attribute of the edges and just calculates how many edges are being visited. For this purpose an attribute _**Dependency**_ is added to the Edge class. **Edge Dependency** means how much a certain vertex is dependent on another vertex. This value can we obtained if we use process mining technique to generate a model of the SUT.  