### PR TITLE
Added offending file's path to the message of ContextFactoryException

### DIFF
--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/ContextFactoryScanner.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/ContextFactoryScanner.java
@@ -88,7 +88,7 @@ public final class ContextFactoryScanner {
         return factory;
       }
     }
-    throw new ContextFactoryException("No suitable context factory found");
+    throw new ContextFactoryException("No suitable context factory found for file: " + path.toString());
   }
 
   private static ContextFactory create(Class<? extends ContextFactory> factoryClass) {


### PR DESCRIPTION
ContextFactoryScanner throws an exception with the following message when it does not find a ContextFactory for an extension: "No suitable context factory found".

It is rather cryptic for new users, it is not obvious whether it is a critical error or not. It can be harmless, e.g. if there is a logging configuration file (logback.xml) in test/resources.

Adding the path of the file to the message would help to understand the problem.

I was not sure whether path can be relative (in the cases I have seen it was always absolute).  If it can be, then path.toAbsolutePath().toString() would be probably better. 