### PR TITLE
Remove check for variable name context

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
@@ -360,6 +360,6 @@ public abstract class ExecutionContext extends SimpleScriptContext implements Co
   }
 
   private boolean isVariable(String key, List<String> methods) {
-    return !"impl".equals(key) && !methods.contains(key) && !"print".equals(key) && !"println".equals(key) && !"context".equals(key);
+    return !"impl".equals(key) && !methods.contains(key) && !"print".equals(key) && !"println".equals(key);
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/SimpleMachineTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/SimpleMachineTest.java
@@ -356,4 +356,17 @@ public class SimpleMachineTest {
     assertArrayEquals(expectedPath.toArray(), context.getProfiler().getPath().toArray());
   }
 
+  @Test
+  public void executeActionWithVariableNameContext() {
+    Vertex vertex1 = new Vertex();
+    Vertex vertex2 = new Vertex();
+    Model model = new Model()
+      .addEdge(new Edge().setSourceVertex(vertex1).setTargetVertex(vertex2))
+      .addEdge(new Edge().setSourceVertex(vertex2).setTargetVertex(vertex1));
+    model.addAction(new Action("context = 1;"));
+    Context context = new TestExecutionContext(model, new RandomPath(new EdgeCoverage(100)));
+    context.setNextElement(vertex1);
+    Machine machine = new SimpleMachine(context);
+    assertThat(machine.getCurrentContext().getKeys().containsKey("context"), is(true));
+  }
 }


### PR DESCRIPTION
@KristianKarl I added the test from the issue and removed the check for "context", it might be a legacy from before the mirroring between javascript and java.

Fixes https://github.com/GraphWalker/graphwalker-project/issues/77