### PR TITLE
Conform multiple generator toString() output to documentation

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/CombinedPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/CombinedPath.java
@@ -107,7 +107,7 @@ public final class CombinedPath extends PathGeneratorBase<StopCondition> {
     while (iterator.hasNext()) {
       builder = iterator.next().toString(builder);
       if (iterator.hasNext()) {
-        builder.append(" AND ");
+        builder.append(" ");
       }
     }
     return builder;

--- a/graphwalker-core/src/test/java/org/graphwalker/core/generator/CombinedPathTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/generator/CombinedPathTest.java
@@ -88,6 +88,6 @@ public class CombinedPathTest {
     assertEquals("RandomPath(ReachedVertex(v1))", generator.toString());
     generator.addPathGenerator(new RandomPath(new ReachedVertex("v2")));
     assertEquals(generator.getPathGenerators().size(), 2);
-    assertEquals("RandomPath(ReachedVertex(v1)) AND RandomPath(ReachedVertex(v2))", generator.toString());
+    assertEquals("RandomPath(ReachedVertex(v1)) RandomPath(ReachedVertex(v2))", generator.toString());
   }
 }


### PR DESCRIPTION
The documentation, http://graphwalker.github.io/generators_and_stop_conditions/, expects only white space between multiple generators.