### PR TITLE
Allow using test resources for model generation

### DIFF
--- a/graphwalker-maven-plugin/src/main/java/org/graphwalker/maven/plugin/GenerateMainMojo.java
+++ b/graphwalker-maven-plugin/src/main/java/org/graphwalker/maven/plugin/GenerateMainMojo.java
@@ -43,6 +43,12 @@ public final class GenerateMainMojo extends GenerateMojoBase {
   @Parameter(property = "graphwalker.generate.directory", defaultValue = "${project.build.directory}/generated-sources/graphwalker")
   private File generatedSourcesDirectory;
 
+  @Parameter(property = "graphwalker.generate.include.production.resources", defaultValue = "true")
+  private boolean includeProductionResources;
+
+  @Parameter(property = "graphwalker.generate.include.test.resources", defaultValue = "false")
+  private boolean includeTestResources;
+
   @Override
   protected File getGeneratedSourcesDirectory() {
     return generatedSourcesDirectory;
@@ -50,7 +56,14 @@ public final class GenerateMainMojo extends GenerateMojoBase {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    generate(getMavenProject().getResources());
+    if (includeProductionResources) {
+      getLog().info("Generating based on maven production resources");
+      generate(getMavenProject().getResources());
+    }
+    if (includeTestResources) {
+      getLog().info("Generating based on maven test resources");
+      generate(getMavenProject().getTestResources());
+    }
     if (getGeneratedSourcesDirectory().exists()) {
       getMavenProject().addCompileSourceRoot(getGeneratedSourcesDirectory().getPath());
     }


### PR DESCRIPTION
I would like to have my models (graphml files) in the test resources folders so that I can write test for files in the main src folder in the seperate test folder. The proposed solution adds to new maven parameters to the generate-sources goal:

* includeProductionResources: true by default - includes the production resources into the generate process
* includeTestResources: false by default - includes the test resources into the generate process

The user can combine the parameters to include both production and test resources, or disable the production resources and have just the test resources included.