### PR TITLE
Fix issue with executing multiple start contexts

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+#
+# This codecov.yml is the default configuration for
+# all repositories on Codecov. You may adjust the settings
+# below in your own codecov.yml in your repository.
+#
+coverage:
+  precision: 2
+  round: down
+  range: 70...100
+
+  status:
+    # Learn more at http://docs.codecov.io/docs/codecov-yaml
+    project: true
+    patch: false
+    changes: false
+
+comment:
+  layout: "header, diff"
+  behavior: default  # update if exists else create new

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@
 coverage:
   precision: 2
   round: down
-  range: 70...100
+  range: 50...80
 
   status:
     # Learn more at http://docs.codecov.io/docs/codecov-yaml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,12 @@
-#
-# This codecov.yml is the default configuration for
-# all repositories on Codecov. You may adjust the settings
-# below in your own codecov.yml in your repository.
-#
 coverage:
   precision: 2
   round: down
   range: 50...80
 
   status:
-    # Learn more at http://docs.codecov.io/docs/codecov-yaml
-    project: true
+    project:
+      default:
+        threshold: 1%
     patch: false
     changes: false
 

--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/SimpleMachine.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/SimpleMachine.java
@@ -156,10 +156,14 @@ public class SimpleMachine extends MachineBase {
     return context;
   }
 
+  private boolean isStartContext(Context context) {
+    return hasNextStep(context) && (isNotNull(context.getCurrentElement()) || isNotNull(context.getNextElement()));
+  }
+
   private Context findStartContext() {
     Context startContext = null;
     for (Context context : getContexts()) {
-      if (hasNextStep(context) && (isNotNull(context.getCurrentElement()) || isNotNull(context.getNextElement()))) {
+      if (isStartContext(context)) {
         startContext = context;
         break;
       }
@@ -237,6 +241,9 @@ public class SimpleMachine extends MachineBase {
     MDC.put("trace", UUID.randomUUID().toString());
     for (Context context : getContexts()) {
       if (hasNextStep(context)) {
+        if (!context.equals(getCurrentContext()) && isStartContext(context)) {
+          switchContext(context);
+        }
         return true;
       }
     }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
@@ -32,6 +32,9 @@ import org.graphwalker.core.model.Element;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @author Nils Olsson
+ */
 public class Profile {
 
   private final Context context;

--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profiler.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profiler.java
@@ -33,6 +33,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @author Nils Olsson
+ */
 public interface Profiler {
   void addContext(Context context);
   Set<Context> getContexts();

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/MultipleContextTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/MultipleContextTest.java
@@ -1,0 +1,24 @@
+package org.graphwalker.core.machine;
+
+import org.graphwalker.core.model.Edge;
+import org.graphwalker.core.model.Model;
+import org.graphwalker.core.model.Vertex;
+import org.junit.Test;
+
+public class MultipleContextTest {
+
+  Vertex start = new Vertex();
+  Vertex stop = new Vertex();
+  Edge edge = new Edge().setSourceVertex(start).setTargetVertex(stop);
+  Model model = new Model().addEdge(edge);
+
+  @Test
+  public void multipleContexts() throws Exception {
+    Context contextA = new TestExecutionContext(model).setNextElement(start);
+    Context contextB = new TestExecutionContext(model).setNextElement(start);
+    Machine machine = new SimpleMachine(contextA, contextB);
+    while (machine.hasNextStep()) {
+      machine.getNextStep();
+    }
+  }
+}

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/TestExecutionContext.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/TestExecutionContext.java
@@ -30,7 +30,10 @@ import static org.graphwalker.core.model.Model.RuntimeModel;
 
 import javax.script.Bindings;
 import javax.script.SimpleBindings;
+
+import org.graphwalker.core.condition.EdgeCoverage;
 import org.graphwalker.core.generator.PathGenerator;
+import org.graphwalker.core.generator.RandomPath;
 import org.graphwalker.core.model.Model;
 
 /**
@@ -42,6 +45,11 @@ public final class TestExecutionContext extends ExecutionContext {
 
   public TestExecutionContext() {
     super();
+    getScriptEngine().put("global", bindings);
+  }
+
+  public TestExecutionContext(Model model) {
+    super(model, new RandomPath(new EdgeCoverage(100)));
     getScriptEngine().put("global", bindings);
   }
 


### PR DESCRIPTION
A start context is context with a defined start point, thus making it possible to execute

Currently the machine implementation will fail if it executes multiple start contexts at the same time, this PR will fix that by adding the possibility to switch to another unfinished start context when the current context is finished.