### PR TITLE
Throw exception when no execution exists

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/MissingExecutionException.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/MissingExecutionException.java
@@ -26,5 +26,5 @@ package org.graphwalker.core.statistics;
  * #L%
  */
 
-public class NoExecutionException extends RuntimeException {
+public class MissingExecutionException extends RuntimeException {
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/NoExecutionException.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/NoExecutionException.java
@@ -1,0 +1,30 @@
+package org.graphwalker.core.statistics;
+
+/*-
+ * #%L
+ * GraphWalker Core
+ * %%
+ * Copyright (C) 2005 - 2017 GraphWalker
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+public class NoExecutionException extends RuntimeException {
+}

--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
@@ -66,7 +66,7 @@ public class Profile {
   public long getMinExecutionTime(TimeUnit unit) {
     return unit.convert(executions.stream()
       .mapToLong(Execution::getDuration).min()
-      .orElseThrow(NoExecutionException::new), TimeUnit.NANOSECONDS);
+      .orElseThrow(MissingExecutionException::new), TimeUnit.NANOSECONDS);
   }
 
   public long getMaxExecutionTime() {
@@ -76,7 +76,7 @@ public class Profile {
   public long getMaxExecutionTime(TimeUnit unit) {
     return unit.convert(executions.stream()
       .mapToLong(Execution::getDuration).max()
-      .orElseThrow(NoExecutionException::new), TimeUnit.NANOSECONDS);
+      .orElseThrow(MissingExecutionException::new), TimeUnit.NANOSECONDS);
   }
 
   public long getTotalExecutionTime() {
@@ -95,7 +95,7 @@ public class Profile {
   public long getAverageExecutionTime(TimeUnit unit) {
     return unit.convert(Math.round(executions.stream()
       .mapToLong(Execution::getDuration).average()
-      .orElseThrow(NoExecutionException::new)), TimeUnit.NANOSECONDS);
+      .orElseThrow(MissingExecutionException::new)), TimeUnit.NANOSECONDS);
   }
 
   public long getFirstExecutionTime() {
@@ -104,7 +104,7 @@ public class Profile {
 
   public long getFirstExecutionTime(TimeUnit unit) {
     return executions.stream().findFirst()
-      .orElseThrow(NoExecutionException::new).getDuration(unit);
+      .orElseThrow(MissingExecutionException::new).getDuration(unit);
   }
 
   public long getLastExecutionTime() {
@@ -113,6 +113,6 @@ public class Profile {
 
   public long getLastExecutionTime(TimeUnit unit) {
     return executions.stream().reduce((first, second) -> second)
-      .orElseThrow(NoExecutionException::new).getDuration(unit);
+      .orElseThrow(MissingExecutionException::new).getDuration(unit);
   }
 }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/Profile.java
@@ -65,7 +65,8 @@ public class Profile {
 
   public long getMinExecutionTime(TimeUnit unit) {
     return unit.convert(executions.stream()
-      .mapToLong(Execution::getDuration).min().getAsLong(), TimeUnit.NANOSECONDS);
+      .mapToLong(Execution::getDuration).min()
+      .orElseThrow(NoExecutionException::new), TimeUnit.NANOSECONDS);
   }
 
   public long getMaxExecutionTime() {
@@ -74,7 +75,8 @@ public class Profile {
 
   public long getMaxExecutionTime(TimeUnit unit) {
     return unit.convert(executions.stream()
-      .mapToLong(Execution::getDuration).max().getAsLong(), TimeUnit.NANOSECONDS);
+      .mapToLong(Execution::getDuration).max()
+      .orElseThrow(NoExecutionException::new), TimeUnit.NANOSECONDS);
   }
 
   public long getTotalExecutionTime() {
@@ -92,7 +94,8 @@ public class Profile {
 
   public long getAverageExecutionTime(TimeUnit unit) {
     return unit.convert(Math.round(executions.stream()
-      .mapToLong(Execution::getDuration).average().getAsDouble()), TimeUnit.NANOSECONDS);
+      .mapToLong(Execution::getDuration).average()
+      .orElseThrow(NoExecutionException::new)), TimeUnit.NANOSECONDS);
   }
 
   public long getFirstExecutionTime() {
@@ -100,7 +103,8 @@ public class Profile {
   }
 
   public long getFirstExecutionTime(TimeUnit unit) {
-    return executions.stream().findFirst().get().getDuration(unit);
+    return executions.stream().findFirst()
+      .orElseThrow(NoExecutionException::new).getDuration(unit);
   }
 
   public long getLastExecutionTime() {
@@ -108,6 +112,7 @@ public class Profile {
   }
 
   public long getLastExecutionTime(TimeUnit unit) {
-    return executions.stream().reduce((first, second) -> second).get().getDuration(unit);
+    return executions.stream().reduce((first, second) -> second)
+      .orElseThrow(NoExecutionException::new).getDuration(unit);
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/statistics/ProfileTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/statistics/ProfileTest.java
@@ -32,6 +32,7 @@ import org.graphwalker.core.model.Vertex;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -86,5 +87,39 @@ public class ProfileTest {
     assertThat(profile.getFirstExecutionTime(TimeUnit.MICROSECONDS), is(1L));
     assertThat(profile.getLastExecutionTime(TimeUnit.MICROSECONDS), is(2L));
     assertThat(profile.getTotalExecutionTime(TimeUnit.MICROSECONDS), is(6L));
+  }
+
+  @Test
+  public void emptyProfile() throws Exception {
+    Profile profile = new Profile(context, vertex, Collections.emptyList());
+    assertThat(profile.getContext(), is(context));
+    assertThat(profile.getElement(), is(vertex));
+    assertThat(profile.getExecutionCount(), is(0L));
+    assertThat(profile.getTotalExecutionTime(), is(0L));
+  }
+
+  @Test(expected = NoExecutionException.class)
+  public void noAverageExecutionTime() throws Exception {
+    new Profile(context, vertex, Collections.emptyList()).getAverageExecutionTime();
+  }
+
+  @Test(expected = NoExecutionException.class)
+  public void noMinExecutionTime() throws Exception {
+    new Profile(context, vertex, Collections.emptyList()).getMinExecutionTime();
+  }
+
+  @Test(expected = NoExecutionException.class)
+  public void noMaxExecutionTime() throws Exception {
+    new Profile(context, vertex, Collections.emptyList()).getMaxExecutionTime();
+  }
+
+  @Test(expected = NoExecutionException.class)
+  public void noFirstExecutionTime() throws Exception {
+    new Profile(context, vertex, Collections.emptyList()).getFirstExecutionTime();
+  }
+
+  @Test(expected = NoExecutionException.class)
+  public void noLastExecutionTime() throws Exception {
+    new Profile(context, vertex, Collections.emptyList()).getLastExecutionTime();
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/statistics/ProfileTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/statistics/ProfileTest.java
@@ -98,27 +98,27 @@ public class ProfileTest {
     assertThat(profile.getTotalExecutionTime(), is(0L));
   }
 
-  @Test(expected = NoExecutionException.class)
+  @Test(expected = MissingExecutionException.class)
   public void noAverageExecutionTime() throws Exception {
     new Profile(context, vertex, Collections.emptyList()).getAverageExecutionTime();
   }
 
-  @Test(expected = NoExecutionException.class)
+  @Test(expected = MissingExecutionException.class)
   public void noMinExecutionTime() throws Exception {
     new Profile(context, vertex, Collections.emptyList()).getMinExecutionTime();
   }
 
-  @Test(expected = NoExecutionException.class)
+  @Test(expected = MissingExecutionException.class)
   public void noMaxExecutionTime() throws Exception {
     new Profile(context, vertex, Collections.emptyList()).getMaxExecutionTime();
   }
 
-  @Test(expected = NoExecutionException.class)
+  @Test(expected = MissingExecutionException.class)
   public void noFirstExecutionTime() throws Exception {
     new Profile(context, vertex, Collections.emptyList()).getFirstExecutionTime();
   }
 
-  @Test(expected = NoExecutionException.class)
+  @Test(expected = MissingExecutionException.class)
   public void noLastExecutionTime() throws Exception {
     new Profile(context, vertex, Collections.emptyList()).getLastExecutionTime();
   }


### PR DESCRIPTION
When calling some methods in the Profile class that only works when there are executions available will now throw a NoExecutionException e.g. `getAverageExecutionTime()` 