### PR TITLE
Add support for loading the model before assigning path generator

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedEdge.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedEdge.java
@@ -56,6 +56,7 @@ public class ReachedEdge extends ReachedStopConditionBase {
 
   @Override
   protected void validate(Context context) {
+    super.validate(context);
     if (isNotNull(context) && isNull(context.getModel().findEdges(getValue()))) {
       throw new StopConditionException("Edge [" + getValue() + "] not found");
     }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedSharedState.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedSharedState.java
@@ -57,6 +57,7 @@ public class ReachedSharedState extends ReachedStopConditionBase {
 
   @Override
   protected void validate(Context context) {
+    super.validate(context);
     if (isNotNull(context) && isNull(context.getModel().getSharedStates(getValue()))) {
       throw new StopConditionException("Shared state not found");
     }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedStopConditionBase.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedStopConditionBase.java
@@ -51,8 +51,8 @@ public abstract class ReachedStopConditionBase extends StopConditionBase impleme
   }
 
   protected void validate(Context context) {
-    if (isNotNull(context) && isNull(context.getModel().findElements(getValue()))) {
-      throw new StopConditionException("Element not found");
+    if (isNotNull(context) && isNull(context.getModel())) {
+      throw new StopConditionException("Context missing a model");
     }
   }
 

--- a/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedVertex.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/condition/ReachedVertex.java
@@ -60,6 +60,7 @@ public class ReachedVertex extends ReachedStopConditionBase {
 
   @Override
   protected void validate(Context context) {
+    super.validate(context);
     if (isNotNull(context) && isNull(context.getModel().findVertices(getValue()))) {
       throw new StopConditionException("Vertex [" + getValue() + "] not found");
     }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/SimpleMachineTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/SimpleMachineTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import org.graphwalker.core.condition.EdgeCoverage;
 import org.graphwalker.core.condition.ReachedVertex;
+import org.graphwalker.core.condition.StopConditionException;
 import org.graphwalker.core.condition.VertexCoverage;
 import org.graphwalker.core.generator.AStarPath;
 import org.graphwalker.core.generator.RandomPath;
@@ -424,5 +425,11 @@ public class SimpleMachineTest {
     public void handle(Machine machine, MachineException exception) {
 
     }
+  }
+
+  @Test(expected = StopConditionException.class)
+  public void setReachedStopConditionWithoutModel() throws Exception {
+    Context context = new TestExecutionContext();
+    context.setPathGenerator(new RandomPath(new ReachedVertex("X")));
   }
 }

--- a/graphwalker-java/src/main/java/org/graphwalker/java/test/TestBuilder.java
+++ b/graphwalker-java/src/main/java/org/graphwalker/java/test/TestBuilder.java
@@ -54,6 +54,7 @@ public final class TestBuilder {
     return this;
   }
 
+  @Deprecated
   public TestBuilder addContext(Context context, Path path) throws IOException {
     List<Context> pathContexts = ContextFactoryScanner.get(path).create(path);
     if (isNullOrEmpty(pathContexts)) {
@@ -81,6 +82,33 @@ public final class TestBuilder {
     context.setPathGenerator(pathGenerator);
     contexts.add(context);
     return this;
+  }
+
+  public TestBuilder addContext(Context context, Path model, String pathGenerator) {
+    return addContext(context, model, GeneratorFactory.parse(pathGenerator));
+  }
+
+  public TestBuilder addContext(Context context, Path model, PathGenerator pathGenerator) {
+    addModel(context, model);
+    context.setPathGenerator(pathGenerator);
+    contexts.add(context);
+    return this;
+  }
+
+  private Context addModel(Context context, Path model) {
+    try {
+      List<Context> pathContexts = ContextFactoryScanner.get(model).create(model);
+      if (isNullOrEmpty(pathContexts)) {
+        throw new TestExecutionException("Could not read the model: " + model.toString());
+      } else if (pathContexts.size() > 1) {
+        throw new TestExecutionException("The model path: " + model.toString() + ", has more models than 1. Can only handle 1 model.");
+      }
+      context.setModel(pathContexts.get(0).getModel());
+      context.setNextElement(pathContexts.get(0).getNextElement());
+      return context;
+    } catch (IOException e) {
+      throw new TestExecutionException(e);
+    }
   }
 
   private Context createContext(Class<? extends Context> testClass) {

--- a/graphwalker-java/src/test/java/org/graphwalker/java/test/MultipleModelTest.java
+++ b/graphwalker-java/src/test/java/org/graphwalker/java/test/MultipleModelTest.java
@@ -30,28 +30,45 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.graphwalker.core.condition.EdgeCoverage;
+import org.graphwalker.core.condition.ReachedVertex;
+import org.graphwalker.core.generator.AStarPath;
 import org.graphwalker.core.generator.RandomPath;
+import org.graphwalker.core.machine.Context;
+import org.graphwalker.io.factory.ContextFactoryScanner;
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kristian Karl
  */
 public class MultipleModelTest {
 
-  public final static Path MODEL_PATH_1 = Paths.get("org/graphwalker/java/test/MultipleModel_1.graphml");
-  public final static Path MODEL_PATH_2 = Paths.get("org/graphwalker/java/test/MultipleModel_2.graphml");
+  private final static Path MODEL_PATH_1 = Paths.get("org/graphwalker/java/test/MultipleModel_1.graphml");
+  private final static Path MODEL_PATH_2 = Paths.get("org/graphwalker/java/test/MultipleModel_2.graphml");
 
   @Test
   public void run() throws IOException {
     MultipleModel_1 model_1 = new MultipleModel_1();
     MultipleModel_2 model_2 = new MultipleModel_2();
-
     new TestBuilder()
         .addContext(model_1.setPathGenerator(new RandomPath(new EdgeCoverage(100))), MODEL_PATH_1)
         .addContext(model_2.setPathGenerator(new RandomPath(new EdgeCoverage(100))), MODEL_PATH_2)
         .execute();
-    Assert.assertTrue(model_1.count >= 4);
-    Assert.assertTrue(model_2.count >= 3);
+    assertTrue(model_1.count >= 4);
+    assertTrue(model_2.count >= 3);
+  }
+
+  @Test
+  public void reachedCondition() throws IOException {
+    MultipleModel_1 model_1 = new MultipleModel_1();
+    MultipleModel_2 model_2 = new MultipleModel_2();
+    new TestBuilder()
+      .addContext(model_1, MODEL_PATH_1, new AStarPath(new ReachedVertex("B")))
+      .addContext(model_2, MODEL_PATH_2, new AStarPath(new ReachedVertex("D")))
+      .execute();
+    assertTrue(model_1.count >= 2);
+    assertTrue(model_2.count >= 1);
   }
 }

--- a/graphwalker-java/src/test/java/org/graphwalker/java/test/MultipleModelTest.java
+++ b/graphwalker-java/src/test/java/org/graphwalker/java/test/MultipleModelTest.java
@@ -66,7 +66,7 @@ public class MultipleModelTest {
     MultipleModel_2 model_2 = new MultipleModel_2();
     new TestBuilder()
       .addContext(model_1, MODEL_PATH_1, new AStarPath(new ReachedVertex("B")))
-      .addContext(model_2, MODEL_PATH_2, new AStarPath(new ReachedVertex("D")))
+      .addContext(model_2, MODEL_PATH_2, "a_star(reached_vertex(D))")
       .execute();
     assertTrue(model_1.count >= 2);
     assertTrue(model_2.count >= 1);


### PR DESCRIPTION
Reached stop conditions validate that the state exists in the model, if this occurs before the model is assigned to the context a NPE will be thrown. This PR make it possible to load the model before assigning the path generator and thus also the stop condition.