### PR TITLE
Added required method.

### DIFF
--- a/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
+++ b/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
@@ -352,6 +352,11 @@ public class WebSocketServer extends org.java_websocket.server.WebSocketServer i
   }
 
   @Override
+  public void onStart() {
+    logger.debug("WebSocket service started");
+  }
+
+  @Override
   public void update(Machine machine, Element element, EventType type) {
     logger.info("Received an update from a GraphWalker machine");
     for (Object o : machines.entrySet()) {


### PR DESCRIPTION
New version (1.3.0 -> 1.3.8) of org.java-websocket, Java-WebSocket required onStart

From this commit, the project builds (Java 9 and Maven 3.5) using:
```sh
mvn clean install -Dmaven.test.skip=true
```

There are failing tests.