### PR TITLE
Remove print stacktrace

### DIFF
--- a/graphwalker-restful/src/main/java/org/graphwalker/restful/Restful.java
+++ b/graphwalker-restful/src/main/java/org/graphwalker/restful/Restful.java
@@ -86,7 +86,6 @@ public class Restful {
       setContexts(contexts);
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -114,7 +113,6 @@ public class Restful {
       }
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -139,7 +137,6 @@ public class Restful {
       resultJson = Util.getStepAsJSON(machine, verbose, unvisited);
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson = new JSONObject();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
@@ -162,7 +159,6 @@ public class Restful {
       resultJson.put("data", data);
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -180,7 +176,6 @@ public class Restful {
       machine.getCurrentContext().execute(new Action(script));
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -204,7 +199,6 @@ public class Restful {
       machine = new SimpleMachine(contexts);
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -223,7 +217,6 @@ public class Restful {
       failFastStrategy.handle(machine, new MachineException(machine.getCurrentContext(), new Throwable(reason)));
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }
@@ -242,7 +235,6 @@ public class Restful {
       resultJson = result.getResults();
       resultJson.put("result", "ok");
     } catch (Exception e) {
-      e.printStackTrace();
       resultJson.put("result", "nok");
       resultJson.put("error", e.getMessage());
     }

--- a/graphwalker-restful/src/test/java/org/graphwalker/restful/ResetTest.java
+++ b/graphwalker-restful/src/test/java/org/graphwalker/restful/ResetTest.java
@@ -1,0 +1,54 @@
+package org.graphwalker.restful;
+
+import com.sun.jersey.api.container.grizzly2.GrizzlyServerFactory;
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import com.sun.jersey.api.core.ResourceConfig;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.FileEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.graphwalker.io.common.ResourceUtils;
+import org.junit.*;
+
+import java.io.IOException;
+
+public class ResetTest {
+
+  private static HttpServer server;
+
+  @Before
+  public void startServer() throws Exception {
+    ResourceConfig resourceConfig = new DefaultResourceConfig();
+    Restful restful = new Restful(null, true, true);
+    resourceConfig.getSingletons().add(restful);
+    server = GrizzlyServerFactory.createHttpServer("http://0.0.0.0:9192", resourceConfig);
+    server.start();
+  }
+
+  @After
+  public void stopServer() {
+    server.stop();
+  }
+
+  @Test
+  public void resetEmptyMachine() throws IOException {
+    try (CloseableHttpClient client = HttpClientBuilder.create() .build()) {
+      client.execute(new HttpPut("http://localhost:9192/graphwalker/restart"));
+    }
+  }
+
+  @Test
+  public void resetNotYetStartedMachine() throws IOException {
+    try (CloseableHttpClient client = HttpClientBuilder.create() .build()) {
+      // Load model
+      HttpPost load = new HttpPost("http://localhost:9192/graphwalker/load");
+      load.setEntity(new FileEntity(ResourceUtils.getResourceAsFile("gw3/UC01.json"), ContentType.TEXT_PLAIN));
+      client.execute(load);
+      // Reset model without taking any steps
+      client.execute(new HttpPut("http://localhost:9192/graphwalker/restart"));
+    }
+  }
+}


### PR DESCRIPTION
When restarting a restful machine, before taking any steps, a IndexOutOfBoundsException is displayed in the output, this functionality is actually expected but easy to understand as a real problem. therefore this PR will remove the `e.printStackTrace()` the respons/functionality will still be as before.

fixes https://github.com/GraphWalker/graphwalker-project/issues/200