### PR TITLE
Apply blocked filter in restful when models are loaded via rest api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trusty
 jdk:
 - oraclejdk8
 cache:

--- a/graphwalker-cli/src/main/java/org/graphwalker/cli/CLI.java
+++ b/graphwalker-cli/src/main/java/org/graphwalker/cli/CLI.java
@@ -321,11 +321,8 @@ public class CLI {
       ResourceConfig rc = new DefaultResourceConfig();
       try {
         List<Context> contexts = getContextsWithPathGenerators(online.model.iterator());
-        if (online.blocked) {
-          org.graphwalker.io.common.Util.filterBlockedElements(contexts);
-        }
 
-        rc.getSingletons().add(new Restful(contexts, online.verbose, online.unvisited));
+        rc.getSingletons().add(new Restful(contexts, online.verbose, online.unvisited, online.blocked));
       } catch (MachineException e) {
         System.err.println("Was the argument --model correctly?");
         throw e;

--- a/graphwalker-restful/src/main/java/org/graphwalker/restful/Restful.java
+++ b/graphwalker-restful/src/main/java/org/graphwalker/restful/Restful.java
@@ -60,10 +60,12 @@ public class Restful {
   private Machine machine;
   private Boolean verbose;
   private Boolean unvisited;
+  private Boolean blocked;
 
-  public Restful(List<Context> contexts, Boolean verbose, Boolean unvisited) throws Exception {
+  public Restful(List<Context> contexts, Boolean verbose, Boolean unvisited, Boolean blocked) throws Exception {
     this.verbose = verbose;
     this.unvisited = unvisited;
+    this.blocked = blocked;
 
     if (contexts == null || contexts.isEmpty()) {
       return;
@@ -72,6 +74,9 @@ public class Restful {
   }
 
   public void setContexts(List<Context> contexts) {
+    if (this.blocked) {
+      org.graphwalker.io.common.Util.filterBlockedElements(contexts);
+    }
     this.contexts = contexts;
     machine = new SimpleMachine(this.contexts);
   }

--- a/graphwalker-restful/src/test/java/org/graphwalker/restful/ResetTest.java
+++ b/graphwalker-restful/src/test/java/org/graphwalker/restful/ResetTest.java
@@ -26,7 +26,7 @@ public class ResetTest {
   @Before
   public void startServer() throws Exception {
     ResourceConfig resourceConfig = new DefaultResourceConfig();
-    Restful restful = new Restful(null, true, true);
+    Restful restful = new Restful(null, true, true, true);
     resourceConfig.getSingletons().add(restful);
     server = GrizzlyServerFactory.createHttpServer("http://0.0.0.0:9192", resourceConfig);
     server.start();

--- a/graphwalker-restful/src/test/java/org/graphwalker/restful/RestTest.java
+++ b/graphwalker-restful/src/test/java/org/graphwalker/restful/RestTest.java
@@ -71,7 +71,7 @@ public class RestTest extends ExecutionContext implements RestFlow {
   @BeforeExecution
   public void startServer() throws Exception {
     ResourceConfig rc = new DefaultResourceConfig();
-    rest = new Restful(null, true, true);
+    rest = new Restful(null, true, true, true);
     rc.getSingletons().add(rest);
 
     String url = "http://0.0.0.0:" + 9191;


### PR DESCRIPTION
Right now if you create a restful instance with `blocked` `true`, and you set your models via `load` the blocked filter is not applied.

This pull requests fixes this issue