### PR TITLE
Added the possibility to seed the random generators

### DIFF
--- a/graphwalker-cli/src/test/resources/json/PetClinicWithSeed.json
+++ b/graphwalker-cli/src/test/resources/json/PetClinicWithSeed.json
@@ -1,0 +1,344 @@
+{
+  "name": "GraphWalker Example Test",
+  "models": [
+    {
+      "name": "FindOwners",
+      "id": "476fb419-3d7d-4492-802e-6695fe93f595",
+      "generator": "random(89554871348029, edge_coverage(100))",
+      "vertices": [
+        {
+          "id": "b53814ec-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_FindOwners",
+          "sharedState": "FindOwners",
+          "properties": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "dcb0e896-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_NewOwner",
+          "sharedState": "NewOwner",
+          "properties": {
+            "x": 120.65625,
+            "y": -157.8125
+          }
+        },
+        {
+          "id": "dcb0f200-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_Owners",
+          "properties": {
+            "x": -219.34375,
+            "y": -187.8125
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "dcb0fb88-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_AddOwner",
+          "sourceVertexId": "b53814ec-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0e896-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "dcb0fd5e-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_FindOwners",
+          "sourceVertexId": "dcb0e896-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "b53814ec-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "dcb0fe62-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_Search",
+          "sourceVertexId": "b53814ec-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f200-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "dcb0ff34-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_FindOwners",
+          "sourceVertexId": "dcb0f200-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "b53814ec-468c-11e7-a919-92ebcb67fe33"
+        }
+      ]
+    },
+    {
+      "name": "NewOwner",
+      "id": "b23d193c-287a-4eb9-a318-52ead7680ff7",
+      "generator": "random(89554942549238, edge_coverage(100))",
+      "vertices": [
+        {
+          "id": "dcb0d798-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_NewOwner",
+          "sharedState": "NewOwner",
+          "properties": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "dcb0eab2-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_IncorrectData",
+          "properties": {
+            "x": 131.65625,
+            "y": -205.3125
+          }
+        },
+        {
+          "id": "dcb0f3c2-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_OwnerInformation",
+          "sharedState": "OwnerInformation",
+          "properties": {
+            "x": -284.34375,
+            "y": -143.3125
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "dcb104e8-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_IncorrectData",
+          "sourceVertexId": "dcb0d798-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0eab2-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "dcb10736-468c-11e7-a919-92ebcb67fe33",
+          "sourceVertexId": "dcb0eab2-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0d798-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "dcb10812-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_CorrectData",
+          "sourceVertexId": "dcb0d798-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f3c2-468c-11e7-a919-92ebcb67fe33"
+        }
+      ]
+    },
+    {
+      "name": "OwnerInformation",
+      "id": "5f1149c3-2853-47e6-838d-691bf30406a8",
+      "generator": "random(89555008190353, edge_coverage(100))",
+      "actions": [
+        "numOfPets=0;"
+      ],
+      "vertices": [
+        {
+          "id": "dcb0dba8-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_OwnerInformation",
+          "sharedState": "OwnerInformation",
+          "properties": {
+            "x": -23.34375,
+            "y": -51.8125
+          }
+        },
+        {
+          "id": "dcb0ebb6-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_NewPet",
+          "properties": {
+            "x": -27.34375,
+            "y": 118.1875
+          }
+        },
+        {
+          "id": "dcb0f8a4-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_Pet",
+          "properties": {
+            "x": -317.34375,
+            "y": 7.1875
+          }
+        },
+        {
+          "id": "971ec0b8-468d-11e7-a919-92ebcb67fe33",
+          "name": "v_NewVisit",
+          "properties": {
+            "x": 139.65625,
+            "y": -195.8125
+          }
+        },
+        {
+          "id": "971ec57c-468d-11e7-a919-92ebcb67fe33",
+          "name": "v_FindOwners",
+          "sharedState": "FindOwners",
+          "properties": {
+            "x": -270.34375,
+            "y": -181.8125
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "971ec838-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_AddPetSuccessfully",
+          "actions": [
+            " numOfPets++;"
+          ],
+          "sourceVertexId": "dcb0ebb6-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ecaa4-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_AddNewPet",
+          "sourceVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0ebb6-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ecca2-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_EditPet",
+          "guard": "numOfPets>0",
+          "sourceVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f8a4-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ece78-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_UpdatePet",
+          "sourceVertexId": "dcb0f8a4-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ed0b2-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_AddPetFailed",
+          "sourceVertexId": "dcb0ebb6-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0ebb6-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ed3c8-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_AddVisit",
+          "guard": "numOfPets>0",
+          "sourceVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "971ec0b8-468d-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ed53a-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_VisitAddedSuccessfully",
+          "sourceVertexId": "971ec0b8-468d-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ed738-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_VisitAddedFailed",
+          "sourceVertexId": "971ec0b8-468d-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "971ec0b8-468d-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971edad0-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_FindOwners",
+          "sourceVertexId": "dcb0dba8-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "971ec57c-468d-11e7-a919-92ebcb67fe33"
+        }
+      ]
+    },
+    {
+      "name": "PetClinic",
+      "id": "3f6b365f-7011-4db6-b0cc-e19aa453d9b8",
+      "generator": "random(89555075763648, edge_coverage(100))",
+      "vertices": [
+        {
+          "id": "dcb0dde2-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_HomePage",
+          "sharedState": "HomePage",
+          "properties": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "dcb0ef4e-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_FindOwners",
+          "sharedState": "FindOwners",
+          "properties": {
+            "x": 112.65625,
+            "y": -180.8125
+          }
+        },
+        {
+          "id": "dcb0f8a5-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_Veterinarians",
+          "sharedState": "Veterinarians",
+          "properties": {
+            "x": -246.34375,
+            "y": -153.8125
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "971edcce-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_FindOwners",
+          "sourceVertexId": "dcb0dde2-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0ef4e-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ede36-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_HomePage",
+          "sourceVertexId": "dcb0ef4e-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0dde2-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ee142-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_Veterinarians",
+          "sourceVertexId": "dcb0dde2-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f8a5-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ee2b4-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_HomePage",
+          "sourceVertexId": "dcb0f8a5-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0dde2-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ee5c0-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_Veterinarians",
+          "sourceVertexId": "dcb0ef4e-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f8a5-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971ee732-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_FindOwners",
+          "sourceVertexId": "dcb0f8a5-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0ef4e-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "b53810a0-468c-11e7-a919-92ebcb67fe33",
+          "name": "e_StartBrowser",
+          "targetVertexId": "dcb0dde2-468c-11e7-a919-92ebcb67fe33"
+        }
+      ],
+      "startElementId": "b53810a0-468c-11e7-a919-92ebcb67fe33"
+    },
+    {
+      "name": "Veterinarians",
+      "id": "368a9635-c59a-4285-ad01-cf75b0baa978",
+      "generator": "random(89555139131399, edge_coverage(100))",
+      "vertices": [
+        {
+          "id": "dcb0defa-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_Veterinarians",
+          "sharedState": "Veterinarians",
+          "properties": {
+            "x": 0,
+            "y": 0
+          }
+        },
+        {
+          "id": "dcb0f124-468c-11e7-a919-92ebcb67fe33",
+          "name": "v_SearchResult",
+          "properties": {
+            "x": -213.34375,
+            "y": -138.8125
+          }
+        }
+      ],
+      "edges": [
+        {
+          "id": "971eea2a-468d-11e7-a919-92ebcb67fe33",
+          "name": "e_Search",
+          "sourceVertexId": "dcb0defa-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0f124-468c-11e7-a919-92ebcb67fe33"
+        },
+        {
+          "id": "971eeba6-468d-11e7-a919-92ebcb67fe33",
+          "sourceVertexId": "dcb0f124-468c-11e7-a919-92ebcb67fe33",
+          "targetVertexId": "dcb0defa-468c-11e7-a919-92ebcb67fe33"
+        }
+      ]
+    }
+  ]
+}

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/QuickRandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/QuickRandomPath.java
@@ -1,7 +1,7 @@
 package org.graphwalker.core.generator;
 
 /*
-* #%L
+ * #%L
  * * GraphWalker Core
  * *
  * %%
@@ -26,7 +26,7 @@ package org.graphwalker.core.generator;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  * #L%
-*/
+ */
 
 import org.graphwalker.core.algorithm.AStar;
 import org.graphwalker.core.condition.StopCondition;
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Random;
 
 import static org.graphwalker.core.common.Objects.isNotNull;
 import static org.graphwalker.core.common.Objects.isNull;
@@ -60,9 +61,15 @@ public class QuickRandomPath extends PathGeneratorBase<StopCondition> {
   private static final Logger LOG = LoggerFactory.getLogger(QuickRandomPath.class);
   private final List<Element> elements = new ArrayList<>();
   private Element target = null;
+  private Random random = new Random(System.nanoTime());
 
   public QuickRandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+  }
+
+  public QuickRandomPath(long seed, StopCondition stopCondition) {
+    setStopCondition(stopCondition);
+    random = new Random(seed);
   }
 
   @Override
@@ -71,7 +78,7 @@ public class QuickRandomPath extends PathGeneratorBase<StopCondition> {
     if (elements.isEmpty()) {
       elements.addAll(context.getModel().getElements());
       elements.remove(context.getCurrentElement());
-      Collections.shuffle(elements);
+      Collections.shuffle(elements, random);
     }
     if (isNull(target) || target.equals(context.getCurrentElement())) {
       if (elements.isEmpty()) {

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/QuickRandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/QuickRandomPath.java
@@ -61,15 +61,19 @@ public class QuickRandomPath extends PathGeneratorBase<StopCondition> {
   private static final Logger LOG = LoggerFactory.getLogger(QuickRandomPath.class);
   private final List<Element> elements = new ArrayList<>();
   private Element target = null;
-  private Random random = new Random(System.nanoTime());
+  private Random random;
 
   public QuickRandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+    long seed = System.nanoTime();
+    random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   public QuickRandomPath(long seed, StopCondition stopCondition) {
     setStopCondition(stopCondition);
     random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   @Override

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/RandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/RandomPath.java
@@ -12,10 +12,10 @@ package org.graphwalker.core.generator;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,10 +48,15 @@ public class RandomPath extends PathGeneratorBase<StopCondition> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomPath.class);
 
-  private final Random random = new Random(System.nanoTime());
+  private Random random = new Random(System.nanoTime());
 
   public RandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+  }
+
+  public RandomPath(long seed, StopCondition stopCondition) {
+    setStopCondition(stopCondition);
+    random = new Random(seed);
   }
 
   @Override

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/RandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/RandomPath.java
@@ -47,16 +47,19 @@ import java.util.Random;
 public class RandomPath extends PathGeneratorBase<StopCondition> {
 
   private static final Logger LOG = LoggerFactory.getLogger(RandomPath.class);
-
-  private Random random = new Random(System.nanoTime());
+  private Random random;
 
   public RandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+    long seed = System.nanoTime();
+    random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   public RandomPath(long seed, StopCondition stopCondition) {
     setStopCondition(stopCondition);
     random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   @Override

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/WeightedRandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/WeightedRandomPath.java
@@ -12,10 +12,10 @@ package org.graphwalker.core.generator;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -52,10 +52,15 @@ import java.util.Random;
  */
 public class WeightedRandomPath extends PathGeneratorBase<StopCondition> {
 
-  private final Random random = new Random(System.nanoTime());
+  private Random random = new Random(System.nanoTime());
 
   public WeightedRandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+  }
+
+  public WeightedRandomPath(long seed, StopCondition stopCondition) {
+    setStopCondition(stopCondition);
+    random = new Random(seed);
   }
 
   @Override
@@ -93,8 +98,8 @@ public class WeightedRandomPath extends PathGeneratorBase<StopCondition> {
           sum += edge.getWeight();
           if (sum > 1) {
             throw new MachineException("The sum of all weights in edges from vertex: '"
-                                       + currentElement.getName()
-                                       + "', adds up to more than 1.00");
+              + currentElement.getName()
+              + "', adds up to more than 1.00");
           }
         } else {
           numberOfZeros++;
@@ -127,8 +132,8 @@ public class WeightedRandomPath extends PathGeneratorBase<StopCondition> {
     }
 
     throw new MachineException("Could not calculate which weighted edge to choose from vertex: "
-                               + currentElement.getName()
-                               + "'");
+      + currentElement.getName()
+      + "'");
   }
 }
 

--- a/graphwalker-core/src/main/java/org/graphwalker/core/generator/WeightedRandomPath.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/generator/WeightedRandomPath.java
@@ -32,6 +32,8 @@ import org.graphwalker.core.machine.MachineException;
 import org.graphwalker.core.model.Edge;
 import org.graphwalker.core.model.Element;
 import org.graphwalker.core.model.Vertex;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -52,15 +54,20 @@ import java.util.Random;
  */
 public class WeightedRandomPath extends PathGeneratorBase<StopCondition> {
 
-  private Random random = new Random(System.nanoTime());
+  private static final Logger LOG = LoggerFactory.getLogger(WeightedRandomPath.class);
+  private Random random;
 
   public WeightedRandomPath(StopCondition stopCondition) {
     setStopCondition(stopCondition);
+    long seed = System.nanoTime();
+    random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   public WeightedRandomPath(long seed, StopCondition stopCondition) {
     setStopCondition(stopCondition);
     random = new Random(seed);
+    LOG.info("Seed: " + seed);
   }
 
   @Override

--- a/graphwalker-core/src/test/java/org/graphwalker/core/Models.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/Models.java
@@ -45,10 +45,28 @@ public abstract class Models {
       .setName("B");
 
   private static final Edge EDGE_AB = new Edge()
-      .setId("ab")
-      .setName("ab")
-      .setSourceVertex(VERTEX_A)
-      .setTargetVertex(VERTEX_B);
+    .setId("ab")
+    .setName("ab")
+    .setSourceVertex(VERTEX_A)
+    .setTargetVertex(VERTEX_B);
+
+  private static final Edge EDGE_AB_2 = new Edge()
+    .setId("ab_2")
+    .setName("ab_2")
+    .setSourceVertex(VERTEX_A)
+    .setTargetVertex(VERTEX_B);
+
+  private static final Edge EDGE_AB_3 = new Edge()
+    .setId("ab_3")
+    .setName("ab_3")
+    .setSourceVertex(VERTEX_A)
+    .setTargetVertex(VERTEX_B);
+
+  private static final Edge EDGE_BA = new Edge()
+    .setId("ba")
+    .setName("ba")
+    .setSourceVertex(VERTEX_B)
+    .setTargetVertex(VERTEX_A);
 
   private static final RuntimeModel EMPTY_MODEL = new Model().build();
 
@@ -57,8 +75,15 @@ public abstract class Models {
       .build();
 
   private static final RuntimeModel SIMPLE_MODEL = new Model()
-      .addEdge(EDGE_AB)
-      .build();
+    .addEdge(EDGE_AB)
+    .build();
+
+  private static final RuntimeModel FOUR_EDGES_MODEL = new Model()
+    .addEdge(EDGE_AB)
+    .addEdge(EDGE_AB_2)
+    .addEdge(EDGE_AB_3)
+    .addEdge(EDGE_BA)
+    .build();
 
   public static RuntimeVertex findVertex(RuntimeModel model, String id) {
     return (RuntimeVertex) model.getElementById(id);
@@ -78,5 +103,9 @@ public abstract class Models {
 
   public static Model simpleModel() {
     return new Model(SIMPLE_MODEL);
+  }
+
+  public static Model fourEdgesModel() {
+    return new Model(FOUR_EDGES_MODEL);
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/generator/QuickRandomPathTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/generator/QuickRandomPathTest.java
@@ -12,10 +12,10 @@ package org.graphwalker.core.generator;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,15 +26,8 @@ package org.graphwalker.core.generator;
  * #L%
  */
 
-import static org.graphwalker.core.Models.findEdge;
-import static org.graphwalker.core.Models.findVertex;
-import static org.graphwalker.core.Models.simpleModel;
-import static org.graphwalker.core.Models.singleModel;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.graphwalker.core.algorithm.AlgorithmException;
+import org.graphwalker.core.condition.Length;
 import org.graphwalker.core.condition.VertexCoverage;
 import org.graphwalker.core.machine.Context;
 import org.graphwalker.core.machine.Machine;
@@ -43,9 +36,16 @@ import org.graphwalker.core.machine.TestExecutionContext;
 import org.graphwalker.core.model.Edge.RuntimeEdge;
 import org.graphwalker.core.model.Model.RuntimeModel;
 import org.graphwalker.core.model.Vertex.RuntimeVertex;
-import org.graphwalker.core.statistics.Profiler;
 import org.graphwalker.core.statistics.SimpleProfiler;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.graphwalker.core.Models.*;
+import static org.junit.Assert.*;
 
 /**
  * @author Kristian Karl
@@ -97,5 +97,61 @@ public class QuickRandomPathTest {
     context.setCurrentElement(source);
     assertTrue(generator.hasNextStep());
     generator.getNextStep(); // should fail
+  }
+
+  @Test
+  public void seededGenerator() {
+    RuntimeModel model = fourEdgesModel().build();
+    RuntimeVertex A = findVertex(model, "A");
+    RuntimeVertex B = findVertex(model, "B");
+    RuntimeEdge AB = findEdge(model, "ab");
+    RuntimeEdge AB_2 = findEdge(model, "ab_2");
+    RuntimeEdge AB_3 = findEdge(model, "ab_2");
+    RuntimeEdge BA = findEdge(model, "ba");
+    Context context = new TestExecutionContext().setModel(model).setNextElement(A);
+
+    long seed = 1349327921;
+    context.setPathGenerator(new QuickRandomPath(seed, new Length(30)));
+    Machine machine = new SimpleMachine(context);
+
+    List<String> actualPath = new ArrayList<String>();
+    while (machine.hasNextStep()) {
+      machine.getNextStep();
+      actualPath.add(machine.getCurrentContext().getCurrentElement().getId());
+    }
+
+    Assert.assertArrayEquals(new ArrayList<>(Arrays.asList(
+      "A",
+      "ab",
+      "B",
+      "ba",
+      "A",
+      "ab_3",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab",
+      "B",
+      "ba",
+      "A",
+      "ab_3",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B"
+    )).toArray(), actualPath.toArray());
   }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/generator/RandomPathTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/generator/RandomPathTest.java
@@ -12,10 +12,10 @@ package org.graphwalker.core.generator;
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,21 +26,27 @@ package org.graphwalker.core.generator;
  * #L%
  */
 
-import static org.graphwalker.core.Models.findEdge;
-import static org.graphwalker.core.Models.findVertex;
-import static org.graphwalker.core.Models.simpleModel;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import org.graphwalker.core.condition.EdgeCoverage;
+import org.graphwalker.core.condition.Length;
 import org.graphwalker.core.condition.VertexCoverage;
 import org.graphwalker.core.machine.Context;
+import org.graphwalker.core.machine.Machine;
+import org.graphwalker.core.machine.SimpleMachine;
 import org.graphwalker.core.machine.TestExecutionContext;
 import org.graphwalker.core.model.Edge.RuntimeEdge;
 import org.graphwalker.core.model.Model.RuntimeModel;
 import org.graphwalker.core.model.Vertex.RuntimeVertex;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.graphwalker.core.Models.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * @author Nils Olsson
@@ -93,5 +99,61 @@ public class RandomPathTest {
     assertEquals(context.getPathGenerator().getNextStep().getCurrentElement(), edge);
     assertEquals(context.getPathGenerator().getNextStep().getCurrentElement(), target);
     context.getPathGenerator().getNextStep(); // should fail
+  }
+
+  @Test
+  public void seededGenerator() {
+    RuntimeModel model = fourEdgesModel().build();
+    RuntimeVertex A = findVertex(model, "A");
+    RuntimeVertex B = findVertex(model, "B");
+    RuntimeEdge AB = findEdge(model, "ab");
+    RuntimeEdge AB_2 = findEdge(model, "ab_2");
+    RuntimeEdge AB_3 = findEdge(model, "ab_2");
+    RuntimeEdge BA = findEdge(model, "ba");
+    Context context = new TestExecutionContext().setModel(model).setNextElement(A);
+
+    long seed = 1349327921;
+    context.setPathGenerator(new RandomPath(seed, new Length(30)));
+    Machine machine = new SimpleMachine(context);
+
+    List<String> actualPath = new ArrayList<String>();
+    while (machine.hasNextStep()) {
+      machine.getNextStep();
+      actualPath.add(machine.getCurrentContext().getCurrentElement().getId());
+    }
+
+    Assert.assertArrayEquals(new ArrayList<>(Arrays.asList(
+      "A",
+      "ab",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab",
+      "B",
+      "ba",
+      "A",
+      "ab_3",
+      "B",
+      "ba",
+      "A",
+      "ab_2",
+      "B",
+      "ba",
+      "A",
+      "ab",
+      "B"
+    )).toArray(), actualPath.toArray());
   }
 }

--- a/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/GeneratorParser.g4
+++ b/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/GeneratorParser.g4
@@ -9,10 +9,15 @@ parse
  ;
 
 generator
- : Alphanumeric LPAREN logicalExpression RPAREN
- | Alphanumeric LPAREN logicalExpression RPAREN RPAREN {notifyErrorListeners("The generator has too many parentheses");}
- | Alphanumeric LPAREN logicalExpression {notifyErrorListeners("The generator is missing closing parentheses");}
+ : Alphanumeric LPAREN parameters RPAREN
+ | Alphanumeric LPAREN parameters RPAREN RPAREN {notifyErrorListeners("The generator has too many parentheses");}
+ | Alphanumeric LPAREN parameters {notifyErrorListeners("The generator is missing closing parentheses");}
  | Alphanumeric  {notifyErrorListeners("A generator needs parentheses");}
+ ;
+
+parameters
+ : ( logicalExpression
+ | seed COMMA logicalExpression )
  ;
 
 logicalExpression
@@ -34,3 +39,6 @@ stopCondition
  | Alphanumeric)
  ;
 
+seed
+ : Number
+ ;

--- a/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/LogicalLexer.g4
+++ b/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/LogicalLexer.g4
@@ -16,6 +16,10 @@ RPAREN
  : ')'
  ;
 
+COMMA
+ : ','
+ ;
+
 WHITESPACE
  : [ \t\r\n\u000C]+ -> skip
  ;

--- a/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/LogicalLexer.tokens
+++ b/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/generator/LogicalLexer.tokens
@@ -1,0 +1,11 @@
+OR=1
+AND=2
+LPAREN=3
+RPAREN=4
+COMMA=5
+WHITESPACE=6
+Number=7
+Alphanumeric=8
+'('=3
+')'=4
+','=5

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
@@ -47,7 +47,7 @@ import org.graphwalker.dsl.generator.GeneratorParserBaseListener;
 public class GeneratorLoader extends GeneratorParserBaseListener {
 
   private StopCondition stopCondition = null;
-  private Integer seed = null;
+  private Long seed = null;
   private final List<PathGenerator> pathGenerators = new ArrayList<>();
   private final List<StopCondition> stopConditions = new ArrayList<>();
 
@@ -99,7 +99,7 @@ public class GeneratorLoader extends GeneratorParserBaseListener {
   public void exitSeed(GeneratorParser.SeedContext ctx) {
     String str = ctx.getChild(0).getText();
     if (str != null && str.length() > 0) {
-      seed = Integer.parseInt(str);
+      seed = Long.parseLong(str);
     }
   }
 

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/generator/GeneratorLoader.java
@@ -47,6 +47,7 @@ import org.graphwalker.dsl.generator.GeneratorParserBaseListener;
 public class GeneratorLoader extends GeneratorParserBaseListener {
 
   private StopCondition stopCondition = null;
+  private Integer seed = null;
   private final List<PathGenerator> pathGenerators = new ArrayList<>();
   private final List<StopCondition> stopConditions = new ArrayList<>();
 
@@ -95,17 +96,37 @@ public class GeneratorLoader extends GeneratorParserBaseListener {
   }
 
   @Override
+  public void exitSeed(GeneratorParser.SeedContext ctx) {
+    String str = ctx.getChild(0).getText();
+    if (str != null && str.length() > 0) {
+      seed = Integer.parseInt(str);
+    }
+  }
+
+  @Override
   public void exitGenerator(GeneratorParser.GeneratorContext context) {
     if (stopConditions.size() == 1) {
       stopCondition = stopConditions.get(0);
     }
     String generatorName = context.getChild(0).getText().toLowerCase();
     if ("random".equals(generatorName) || "randompath".equals(generatorName)) {
-      pathGenerators.add(new RandomPath(stopCondition));
+      if (seed == null ) {
+        pathGenerators.add(new RandomPath(stopCondition));
+      } else {
+        pathGenerators.add(new RandomPath(seed, stopCondition));
+      }
     } else if ("weighted_random".equals(generatorName) || "weightedrandompath".equals(generatorName)) {
-      pathGenerators.add(new WeightedRandomPath(stopCondition));
+      if (seed == null ) {
+        pathGenerators.add(new WeightedRandomPath(stopCondition));
+      } else {
+        pathGenerators.add(new WeightedRandomPath(seed, stopCondition));
+      }
     } else if ("quick_random".equals(generatorName) || "quickrandom".equals(generatorName) || "quickrandompath".equals(generatorName)) {
-      pathGenerators.add(new QuickRandomPath(stopCondition));
+      if (seed == null ) {
+        pathGenerators.add(new QuickRandomPath(stopCondition));
+      } else {
+        pathGenerators.add(new QuickRandomPath(seed, stopCondition));
+      }
     } else if ("a_star".equals(generatorName) || "astarpath".equals(generatorName)) {
       pathGenerators.add(new AStarPath((ReachedStopCondition) stopCondition));
     } else if ("shortest_all_paths".equals(generatorName) || "shortestallpaths".equals(generatorName)) {

--- a/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
+++ b/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
@@ -26,6 +26,7 @@ package org.graphwalker.dsl;
  * #L%
  */
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
@@ -49,7 +50,6 @@ import org.graphwalker.core.generator.ShortestAllPaths;
 import org.graphwalker.core.generator.WeightedRandomPath;
 import org.graphwalker.dsl.antlr.DslException;
 import org.graphwalker.dsl.antlr.generator.GeneratorFactory;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -70,244 +70,244 @@ public class GeneratorFactoryTest {
   @Test
   public void random_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void random_edgecoverage() {
     PathGenerator generator = GeneratorFactory.parse("random(edgecoverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void randompath_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("randompath(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void quick_random_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("quick_random(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(QuickRandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(QuickRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void quickrandom_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("quickrandom(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(QuickRandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(QuickRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void quickrandompath_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("quickrandompath(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(QuickRandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(QuickRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void shortest_all_paths_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("shortest_all_paths(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(ShortestAllPaths.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(ShortestAllPaths.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void shortestallpaths_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("shortestallpaths(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(ShortestAllPaths.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(ShortestAllPaths.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void random_vertex_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random(vertex_coverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(VertexCoverage.class));
-    Assert.assertThat(((VertexCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(VertexCoverage.class));
+    assertThat(((VertexCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void random_vertexcoverage() {
     PathGenerator generator = GeneratorFactory.parse("random(vertexcoverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(VertexCoverage.class));
-    Assert.assertThat(((VertexCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(VertexCoverage.class));
+    assertThat(((VertexCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void a_star_reached_vertex() {
     PathGenerator generator = GeneratorFactory.parse("a_star(reached_vertex(v_ABC))");
-    Assert.assertThat(generator, instanceOf(AStarPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(ReachedVertex.class));
-    Assert.assertThat(generator.getStopCondition().getValue(), is("v_ABC"));
+    assertThat(generator, instanceOf(AStarPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(ReachedVertex.class));
+    assertThat(generator.getStopCondition().getValue(), is("v_ABC"));
   }
 
   @Test
   public void random_reached_edge() {
     PathGenerator generator = GeneratorFactory.parse("random(reached_edge(edgeName))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(ReachedEdge.class));
-    Assert.assertThat(generator.getStopCondition().getValue(), is("edgeName"));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(ReachedEdge.class));
+    assertThat(generator.getStopCondition().getValue(), is("edgeName"));
   }
 
   @Test
   public void random_reached_vertex() {
     PathGenerator generator = GeneratorFactory.parse("random(reached_vertex(vertexName))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(ReachedVertex.class));
-    Assert.assertThat(generator.getStopCondition().getValue(), is("vertexName"));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(ReachedVertex.class));
+    assertThat(generator.getStopCondition().getValue(), is("vertexName"));
   }
 
   @Test
   public void random_time_duration() {
     PathGenerator generator = GeneratorFactory.parse("random(time_duration(600))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(TimeDuration.class));
-    Assert.assertThat(((TimeDuration) generator.getStopCondition()).getDuration(), is(600L));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(TimeDuration.class));
+    assertThat(((TimeDuration) generator.getStopCondition()).getDuration(), is(600L));
   }
 
   @Test
   public void random_edge_coverage_and_vertex_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random ( edge_coverage(100) and vertex_coverage (100) )");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(CombinedCondition.class));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(CombinedCondition.class));
   }
 
   @Test
   public void random_reached_vertex_or_reached_edge() {
     PathGenerator generator = GeneratorFactory.parse("random ( reached_vertex(Some_vertex) or reached_edge ( Some_edge ) )");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
 
     AlternativeCondition condition = (AlternativeCondition) generator.getStopCondition();
-    Assert.assertThat(condition.getStopConditions().get(0), instanceOf(ReachedVertex.class));
-    Assert.assertThat(condition.getStopConditions().get(0).getValue(), is("Some_vertex"));
-    Assert.assertThat(condition.getStopConditions().get(1), instanceOf(ReachedEdge.class));
-    Assert.assertThat(condition.getStopConditions().get(1).getValue(), is("Some_edge"));
+    assertThat(condition.getStopConditions().get(0), instanceOf(ReachedVertex.class));
+    assertThat(condition.getStopConditions().get(0).getValue(), is("Some_vertex"));
+    assertThat(condition.getStopConditions().get(1), instanceOf(ReachedEdge.class));
+    assertThat(condition.getStopConditions().get(1).getValue(), is("Some_edge"));
   }
 
   @Test
   public void random_edge_coverage_or_vertex_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random ( edge_coverage(100) or vertex_coverage (100) )");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
   }
 
   @Test
   public void random_edge_coverage_or_time_duration_a_star_reached_vertex() {
     PathGenerator generator = GeneratorFactory.parse("random( edge_coverage(100) or time_duration(500) ) a_star(reached_vertex(v_ABC))");
-    Assert.assertThat(generator, instanceOf(CombinedPath.class));
+    assertThat(generator, instanceOf(CombinedPath.class));
 
     CombinedPath combinedPath = (CombinedPath) generator;
-    Assert.assertThat(combinedPath.getPathGenerators().get(0), instanceOf(RandomPath.class));
-    Assert.assertThat(combinedPath.getPathGenerators().get(1), instanceOf(AStarPath.class));
+    assertThat(combinedPath.getPathGenerators().get(0), instanceOf(RandomPath.class));
+    assertThat(combinedPath.getPathGenerators().get(1), instanceOf(AStarPath.class));
 
     StopCondition condition = combinedPath.getPathGenerators().get(0).getStopCondition();
-    Assert.assertThat(condition, instanceOf(StopCondition.class));
+    assertThat(condition, instanceOf(StopCondition.class));
     AlternativeCondition alternativeCondition = (AlternativeCondition) condition;
-    Assert.assertThat(alternativeCondition.getStopConditions().get(0), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(alternativeCondition.getStopConditions().get(1), instanceOf(TimeDuration.class));
+    assertThat(alternativeCondition.getStopConditions().get(0), instanceOf(EdgeCoverage.class));
+    assertThat(alternativeCondition.getStopConditions().get(1), instanceOf(TimeDuration.class));
 
     condition = combinedPath.getPathGenerators().get(1).getStopCondition();
-    Assert.assertThat(condition, instanceOf(ReachedVertex.class));
-    Assert.assertThat(condition.getValue(), is("v_ABC"));
+    assertThat(condition, instanceOf(ReachedVertex.class));
+    assertThat(condition.getValue(), is("v_ABC"));
   }
 
   @Test
   public void capital_random_reached_vertex_or_reached_edge() {
     PathGenerator generator = GeneratorFactory.parse("RANDOM ( REACHED_VERTEX( Some_vertex) OR REACHED_EDGE( Some_edge ) )");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
 
     AlternativeCondition condition = (AlternativeCondition) generator.getStopCondition();
-    Assert.assertThat(condition.getStopConditions().get(0), instanceOf(ReachedVertex.class));
-    Assert.assertThat(condition.getStopConditions().get(0).getValue(), is("Some_vertex"));
-    Assert.assertThat(condition.getStopConditions().get(1), instanceOf(ReachedEdge.class));
-    Assert.assertThat(condition.getStopConditions().get(1).getValue(), is("Some_edge"));
+    assertThat(condition.getStopConditions().get(0), instanceOf(ReachedVertex.class));
+    assertThat(condition.getStopConditions().get(0).getValue(), is("Some_vertex"));
+    assertThat(condition.getStopConditions().get(1), instanceOf(ReachedEdge.class));
+    assertThat(condition.getStopConditions().get(1).getValue(), is("Some_edge"));
   }
 
   @Test
   public void weighted_random_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("weighted_random(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(WeightedRandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(WeightedRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void weightedrandompath_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("weightedrandompath(edge_coverage(100))");
-    Assert.assertThat(generator, instanceOf(WeightedRandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
-    Assert.assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(WeightedRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void random_dependency_edge_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random(dependency_edge_coverage(80))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(DependencyEdgeCoverage.class));
-    Assert.assertThat(((DependencyEdgeCoverage) generator.getStopCondition()).getDependency(), is(80));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(DependencyEdgeCoverage.class));
+    assertThat(((DependencyEdgeCoverage) generator.getStopCondition()).getDependency(), is(80));
   }
 
   @Test
   public void random_dependencyedgecoverage() {
     PathGenerator generator = GeneratorFactory.parse("random(dependencyedgecoverage(80))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(DependencyEdgeCoverage.class));
-    Assert.assertThat(((DependencyEdgeCoverage) generator.getStopCondition()).getDependency(), is(80));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(DependencyEdgeCoverage.class));
+    assertThat(((DependencyEdgeCoverage) generator.getStopCondition()).getDependency(), is(80));
   }
 
   @Test
   public void random_requirement_coverage() {
     PathGenerator generator = GeneratorFactory.parse("random(requirement_coverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(RequirementCoverage.class));
-    Assert.assertThat(((RequirementCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(RequirementCoverage.class));
+    assertThat(((RequirementCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
 
   @Test
   public void random_requirementcoverage() {
     PathGenerator generator = GeneratorFactory.parse("random(requirementcoverage(100))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(RequirementCoverage.class));
-    Assert.assertThat(((RequirementCoverage) generator.getStopCondition()).getPercent(), is(100));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(RequirementCoverage.class));
+    assertThat(((RequirementCoverage) generator.getStopCondition()).getPercent(), is(100));
   }
   
   @Test
   public void randompath_length_coverage() {
     PathGenerator generator = GeneratorFactory.parse("randompath(length(80))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(Length.class));
-    Assert.assertThat(((Length) generator.getStopCondition()).getLength(), is(80L));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(Length.class));
+    assertThat(((Length) generator.getStopCondition()).getLength(), is(80L));
   }
 
   @Test
   public void multipleCombinedStopConditions() {
     PathGenerator generator = GeneratorFactory.parse("random(reached_vertex(isPageOpened) and reached_vertex(isLanguageDetected) and reached_vertex(isTranslateCleared) and reached_edge(openPage))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(CombinedCondition.class));
-    Assert.assertThat(((CombinedCondition) generator.getStopCondition()).getStopConditions().size(), is(4));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(CombinedCondition.class));
+    assertThat(((CombinedCondition) generator.getStopCondition()).getStopConditions().size(), is(4));
   }
 
   @Test
   public void multipleAlternativeStopConditions() {
     PathGenerator generator = GeneratorFactory.parse("random(reached_vertex(isPageOpened) or reached_vertex(isLanguageDetected) or reached_vertex(isTranslateCleared))");
-    Assert.assertThat(generator, instanceOf(RandomPath.class));
-    Assert.assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
-    Assert.assertThat(((AlternativeCondition) generator.getStopCondition()).getStopConditions().size(), is(3));
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
+    assertThat(((AlternativeCondition) generator.getStopCondition()).getStopConditions().size(), is(3));
   }
 }

--- a/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
+++ b/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
@@ -310,4 +310,28 @@ public class GeneratorFactoryTest {
     assertThat(generator.getStopCondition(), instanceOf(AlternativeCondition.class));
     assertThat(((AlternativeCondition) generator.getStopCondition()).getStopConditions().size(), is(3));
   }
+
+  @Test
+  public void random_seed_edge_coverage() {
+    PathGenerator generator = GeneratorFactory.parse("random(123456789, edge_coverage(100))");
+    assertThat(generator, instanceOf(RandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+  }
+
+  @Test
+  public void  weighted_random__seed_edge_coverage() {
+    PathGenerator generator = GeneratorFactory.parse(" weighted_random(123456789, edge_coverage(100))");
+    assertThat(generator, instanceOf(WeightedRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+  }
+
+  @Test
+  public void quickrandom_seed_edge_coverage() {
+    PathGenerator generator = GeneratorFactory.parse("quickrandom(123456789, edge_coverage(100))");
+    assertThat(generator, instanceOf(QuickRandomPath.class));
+    assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
+    assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));
+  }
 }

--- a/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
+++ b/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GeneratorFactoryTest.java
@@ -329,7 +329,7 @@ public class GeneratorFactoryTest {
 
   @Test
   public void quickrandom_seed_edge_coverage() {
-    PathGenerator generator = GeneratorFactory.parse("quickrandom(123456789, edge_coverage(100))");
+    PathGenerator generator = GeneratorFactory.parse("quickrandom(89554871348029579, edge_coverage(100))");
     assertThat(generator, instanceOf(QuickRandomPath.class));
     assertThat(generator.getStopCondition(), instanceOf(EdgeCoverage.class));
     assertThat(((EdgeCoverage) generator.getStopCondition()).getPercent(), is(100));

--- a/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GrammarTest.java
+++ b/graphwalker-dsl/src/test/java/org/graphwalker/dsl/GrammarTest.java
@@ -45,9 +45,12 @@ public class GrammarTest {
 
   private List<String> generators = Arrays.asList(
       "random(never)",
+      "random(123456789, never)",
       "a_star(never)",
       "quick_random(never)",
+      "quick_random(123456789, never)",
       "weighted_random(vertex_coverage(100))",
+      "weighted_random(123456789, vertex_coverage(100))",
       "random(vertex_coverage(100))",
       "random(edge_coverage(100))",
       "random(reached_vertex(v_SomeVertex))",

--- a/graphwalker-io/src/test/resources/json/UC01_with_seed.json
+++ b/graphwalker-io/src/test/resources/json/UC01_with_seed.json
@@ -1,0 +1,134 @@
+{
+  "models": [
+    {
+      "generator": "RandomPath(90835538976957, EdgeCoverage(100))",
+      "startElementId": "e0",
+      "vertices": [
+        {
+          "id": "n4",
+          "name": "v_BrowserStopped"
+        },
+        {
+          "id": "n1",
+          "name": "v_BrowserStarted",
+          "properties": {
+            "color": "yellow"
+          }
+        },
+        {
+          "id": "n2",
+          "name": "v_BaseURL",
+          "requirements": [
+            "UC01 2.2.1"
+          ]
+        },
+        {
+          "id": "n3",
+          "name": "v_SearchResult",
+          "requirements": [
+            "UC01 2.2.2"
+          ]
+        },
+        {
+          "id": "n5",
+          "name": "v_BookInformation",
+          "requirements": [
+            "UC01 2.2.3"
+          ]
+        },
+        {
+          "id": "n6",
+          "name": "v_OtherBoughtBooks"
+        },
+        {
+          "id": "n7",
+          "name": "v_ShoppingCart",
+          "requirements": [
+            "UC01 2.3"
+          ]
+        }
+      ],
+      "edges": [
+        {
+          "id": "e0",
+          "name": "e_init",
+          "actions": [
+            " num_of_books \u003d 0;",
+            " MAX_BOOKS \u003d 5;"
+          ],
+          "targetVertexId": "n4"
+        },
+        {
+          "id": "e1",
+          "name": "e_EnterBaseURL",
+          "sourceVertexId": "n1",
+          "targetVertexId": "n2"
+        },
+        {
+          "id": "e2",
+          "name": "e_SearchBook",
+          "sourceVertexId": "n2",
+          "targetVertexId": "n3"
+        },
+        {
+          "id": "e3",
+          "name": "e_StartBrowser",
+          "sourceVertexId": "n4",
+          "targetVertexId": "n1"
+        },
+        {
+          "id": "e4",
+          "name": "e_ClickBook",
+          "sourceVertexId": "n3",
+          "targetVertexId": "n5"
+        },
+        {
+          "id": "e5",
+          "name": "e_AddBookToCart",
+          "guard": "num_of_books\u003c\u003dMAX_BOOKS",
+          "actions": [
+            " num_of_books++;"
+          ],
+          "sourceVertexId": "n5",
+          "targetVertexId": "n6"
+        },
+        {
+          "id": "e6",
+          "name": "e_ShoppingCart",
+          "sourceVertexId": "n6",
+          "targetVertexId": "n7"
+        },
+        {
+          "id": "e7",
+          "name": "e_ShoppingCart",
+          "sourceVertexId": "n3",
+          "targetVertexId": "n7"
+        },
+        {
+          "id": "e8",
+          "name": "e_ShoppingCart",
+          "sourceVertexId": "n5",
+          "targetVertexId": "n7"
+        },
+        {
+          "id": "e9",
+          "name": "e_SearchBook",
+          "sourceVertexId": "n7",
+          "targetVertexId": "n3"
+        },
+        {
+          "id": "e10",
+          "name": "e_SearchBook",
+          "sourceVertexId": "n6",
+          "targetVertexId": "n3"
+        },
+        {
+          "id": "e11",
+          "name": "e_SearchBook",
+          "sourceVertexId": "n5",
+          "targetVertexId": "n3"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
If a user wants to seed the random path generators, it can be achieved by adding a seed integer, to the as a first parameter to the generator in the JSON model file. Or the generator field in Studio or the CLI
```
random(123456789, edge_coverage(100))
weighted_random(123456789, edge_coverage(100))
quickrandom(123456789, edge_coverage(100))
```

This will generate the same path every time.