### PR TITLE
Seed the random generator from offline command line

### DIFF
--- a/graphwalker-cli/src/main/java/org/graphwalker/cli/CLI.java
+++ b/graphwalker-cli/src/main/java/org/graphwalker/cli/CLI.java
@@ -38,6 +38,7 @@ import org.graphwalker.cli.commands.*;
 import org.graphwalker.cli.util.LoggerUtil;
 import org.graphwalker.cli.util.UnsupportedFileFormat;
 import org.graphwalker.core.event.EventType;
+import org.graphwalker.core.generator.SingletonRandomGenerator;
 import org.graphwalker.core.machine.Context;
 import org.graphwalker.core.machine.MachineException;
 import org.graphwalker.core.machine.SimpleMachine;
@@ -452,10 +453,19 @@ public class CLI {
           System.out.println(Util.getStepAsJSON(machine, offline.verbose, offline.unvisited).toString());
         }
       });
+
+      if (offline.seed != 0) {
+        SingletonRandomGenerator.setSeed(offline.seed);
+      }
+
       executor.execute();
     } else if (!offline.gw3.isEmpty()) {
       //TODO Fix gw3. Should not be there
       List<Context> contexts = new JsonContextFactory().create(Paths.get(offline.gw3));
+
+      if (offline.seed != 0) {
+        SingletonRandomGenerator.setSeed(offline.seed);
+      }
 
       if (offline.blocked) {
         org.graphwalker.io.common.Util.filterBlockedElements(contexts);

--- a/graphwalker-cli/src/main/java/org/graphwalker/cli/commands/Offline.java
+++ b/graphwalker-cli/src/main/java/org/graphwalker/cli/commands/Offline.java
@@ -58,4 +58,8 @@ public class Offline {
   @Parameter(names = {"--blocked",
                       "-b"}, arity = 1, description = "This option enables or disables the BLOCKED feature. When \"-b true\" GraphWalker will filter out elements in models with the keyword BLOCKED. When \"-b false\" GraphWalker will not filter out any elements in models with the keyword BLOCKED.")
   public boolean blocked = true;
+
+  @Parameter(names = {"--seed", "-d"}, required = false,
+    description = "Seed the random generator using the provided number.")
+  public long seed = 0;
 }


### PR DESCRIPTION
When running the CLI using the `offline` command, a new option:
`--seed`  or `-d` can be used to seed the random generator.

**Example:**
```terminal
java -jar graphwalker-cli-4.2.0-SNAPSHOT.jar offline --seed 147945811993279 --model model.json "random(edge_coverage(100))" 
```