### PR TITLE
Adding setData to the websocket api

### DIFF
--- a/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
+++ b/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
@@ -42,6 +42,7 @@ import org.graphwalker.core.event.Observer;
 import org.graphwalker.core.machine.Context;
 import org.graphwalker.core.machine.Machine;
 import org.graphwalker.core.machine.SimpleMachine;
+import org.graphwalker.core.model.Action;
 import org.graphwalker.core.model.Element;
 import org.graphwalker.io.factory.json.JsonContextFactory;
 import org.graphwalker.io.factory.yed.YEdContextFactory;
@@ -228,6 +229,25 @@ public class WebSocketServer extends org.java_websocket.server.WebSocketServer i
             obj.put("data", data);
             obj.put("result", "ok");
             response.put("data", data);
+            response.put("success", true);
+          } catch (Exception e) {
+            logger.error(e.getMessage());
+            sendIssue(socket, e.getMessage());
+          }
+        } else {
+          response.put("message", "The GraphWalker state machine is not initiated. Is a model loaded, and started?");
+        }
+        break;
+      }
+      case "SETDATA": {
+        response.put("command", "setData");
+        response.put("success", false);
+        Machine machine = machines.get(socket);
+        if (machine != null) {
+          JSONObject obj = new JSONObject();
+          try {
+            machine.getCurrentContext().execute(new Action(root.getString("action")));
+            obj.put("result", "ok");
             response.put("success", true);
           } catch (Exception e) {
             logger.error(e.getMessage());

--- a/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketClient.java
+++ b/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketClient.java
@@ -50,12 +50,14 @@ public class WebSocketClient {
     START,
     GETNEXT,
     GETDATA,
-    VISITEDELEMENT
+    SETDATA,
+    VISITEDELEMENT;
   }
 
   public boolean connected = false;
   public RX_STATE rxState = RX_STATE.NONE;
   public boolean cmd = false;
+  public String response = "";
   public boolean hasNext = false;
   private int port = 8887;
   private String host = "localhost";
@@ -142,6 +144,17 @@ public class WebSocketClient {
               break;
             case "GETDATA":
               rxState = RX_STATE.GETDATA;
+              if (root.getBoolean("success")) {
+                cmd = true;
+              }
+              if (root.has("data")) {
+                response = root.getJSONObject("data").toString();
+              } else {
+                response = "";
+              }
+              break;
+            case "SETDATA":
+              rxState = RX_STATE.SETDATA;
               if (root.getBoolean("success")) {
                 cmd = true;
               }
@@ -267,9 +280,16 @@ public class WebSocketClient {
   /**
    * Asks the machine to return all data from the current model context.
    */
-  public void getData() {
+  public String getData() {
     logger.debug("Get data");
     client.wsc.send("{ command: \"getData\"}");
     wait(client, RX_STATE.GETDATA);
+    return client.response;
+  }
+
+  public void setData(String action) {
+    logger.debug("Set data as an action: " + action);
+    client.wsc.send("{ command: \"setData\", action: \"" + action + "\"}");
+    wait(client, RX_STATE.SETDATA);
   }
 }

--- a/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketServerTest.java
+++ b/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketServerTest.java
@@ -30,12 +30,16 @@ import static org.hamcrest.CoreMatchers.is;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+
+import netscape.javascript.JSObject;
+import org.graphwalker.core.generator.SingletonRandomGenerator;
 import org.graphwalker.core.machine.ExecutionContext;
 import org.graphwalker.java.annotation.BeforeExecution;
 import org.graphwalker.java.annotation.GraphWalker;
 import org.graphwalker.java.test.TestExecutionException;
 import org.graphwalker.java.test.TestExecutor;
 import org.java_websocket.WebSocket;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -52,9 +56,11 @@ public class WebSocketServerTest extends ExecutionContext implements WebSocketFl
   private WebSocketClient client = new WebSocketClient();
   private WebSocketServer server;
   private int numberOfConnections = 0;
+  private int expectedValue = 54686327;
 
   @BeforeExecution
   public void startServer() throws Exception {
+    SingletonRandomGenerator.setSeed(222930684376058L);
     server = new WebSocketServer(8887);
     server.start();
   }
@@ -107,7 +113,15 @@ public class WebSocketServerTest extends ExecutionContext implements WebSocketFl
 
   @Override
   public void e_GetData() {
-    client.getData();
+    String response =  client.getData();
+    JSONObject jsonObject = new JSONObject(response);
+    Assert.assertEquals(expectedValue, jsonObject.getInt("value"));
+  }
+
+  @Override
+  public void e_SetData() {
+    expectedValue = SingletonRandomGenerator.nextInt();
+    client.setData("value=" + expectedValue);
   }
 
   @Override

--- a/graphwalker-websocket/src/test/resources/json/SmallModel.json
+++ b/graphwalker-websocket/src/test/resources/json/SmallModel.json
@@ -5,6 +5,9 @@
       "name": "SmallModel",
       "generator": "random(edge_coverage(100))",
       "startElementId": "e0",
+      "actions": [
+        "value=54686327;"
+      ],
       "vertices": [
         {
           "name": "v_VerifySomeAction",

--- a/graphwalker-websocket/src/test/resources/org/graphwalker/websocket/WebSocketFlow.graphml
+++ b/graphwalker-websocket/src/test/resources/org/graphwalker/websocket/WebSocketFlow.graphml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:java="http://www.yworks.com/xml/yfiles-common/1.0/java" xmlns:sys="http://www.yworks.com/xml/yfiles-common/markup/primitives/2.0" xmlns:x="http://www.yworks.com/xml/yfiles-common/markup/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:y="http://www.yworks.com/xml/graphml" xmlns:yed="http://www.yworks.com/xml/yed/3" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://www.yworks.com/xml/schema/graphml/1.1/ygraphml.xsd">
-  <!--Created by yEd 3.14.4-->
+  <!--Created by yEd 3.16.1-->
   <key attr.name="Description" attr.type="string" for="graph" id="d0"/>
   <key for="port" id="d1" yfiles.type="portgraphics"/>
   <key for="port" id="d2" yfiles.type="portgeometry"/>
@@ -17,10 +17,10 @@
     <node id="n0">
       <data key="d6">
         <y:GenericNode configuration="ShinyPlateNode3">
-          <y:Geometry height="30.0" width="43.314453125" x="221.6566623263889" y="0.0"/>
+          <y:Geometry height="30.0" width="43.314453125" x="197.28126550099208" y="0.0"/>
           <y:Fill color="#00FF00" transparent="false"/>
           <y:BorderStyle hasColor="false" type="line" width="1.0"/>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="custom" textColor="#000000" visible="true" width="33.314453125" x="5.0" y="6.015625">Start<y:LabelModel>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="30.925201416015625" x="6.1946258544921875" y="4.832489013671875">Start<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>
             <y:ModelParameter>
@@ -33,10 +33,10 @@
     <node id="n1">
       <data key="d6">
         <y:GenericNode configuration="ShinyPlateNode3">
-          <y:Geometry height="30.0" width="116.02929687500003" x="185.29924045138887" y="87.96875000000001"/>
+          <y:Geometry height="30.0" width="116.02929687500003" x="160.92384362599205" y="90.33502197265626"/>
           <y:Fill color="#FF9900" transparent="false"/>
           <y:BorderStyle hasColor="false" type="line" width="1.0"/>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="custom" textColor="#000000" visible="true" width="106.029296875" x="5.0" y="6.015625">v_EmptyMachine<y:LabelModel>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="99.16769409179688" x="8.430801391601562" y="4.832489013671875">v_EmptyMachine<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>
             <y:ModelParameter>
@@ -49,10 +49,10 @@
     <node id="n2">
       <data key="d6">
         <y:GenericNode configuration="ShinyPlateNode3">
-          <y:Geometry height="30.0" width="127.044921875" x="128.97357080853175" y="381.3125"/>
+          <y:Geometry height="30.0" width="127.044921875" x="102.48071366567461" y="412.34515380859375"/>
           <y:Fill color="#FF9900" transparent="false"/>
           <y:BorderStyle hasColor="false" type="line" width="1.0"/>
-          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="custom" textColor="#000000" visible="true" width="117.044921875" x="5.0" y="6.015625">v_MachineRunning<y:LabelModel>
+          <y:NodeLabel alignment="center" autoSizePolicy="content" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="custom" textColor="#000000" verticalTextPosition="bottom" visible="true" width="111.04116821289062" x="8.001876831054688" y="4.832489013671875">v_MachineRunning<y:LabelModel>
               <y:SmartNodeLabelModel distance="4.0"/>
             </y:LabelModel>
             <y:ModelParameter>
@@ -68,7 +68,7 @@
           <y:Path sx="0.0" sy="15.0" tx="0.0" ty="-15.0"/>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="67.0" x="-33.49999966091582" y="25.0">e_Connect<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="62.59979248046875" x="-62.59989599803137" y="25.0">e_Connect<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:QuadCurveEdge>
       </data>
@@ -76,10 +76,10 @@
     <edge id="e1" source="n1" target="n2">
       <data key="d10">
         <y:QuadCurveEdge straightness="0.1">
-          <y:Path sx="0.0" sy="15.0" tx="50.81796874999998" ty="-15.0"/>
+          <y:Path sx="0.0" sy="15.0" tx="52.93538411458334" ty="-15.0"/>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="96.9296875" x="-48.46484341091582" y="25.00000000000003">e_StartMachine<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="91.06015014648438" x="-91.06023356119792" y="25.00000000000003">e_StartMachine<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:QuadCurveEdge>
       </data>
@@ -87,14 +87,14 @@
     <edge id="e2" source="n2" target="n2">
       <data key="d10">
         <y:QuadCurveEdge straightness="0.1">
-          <y:Path sx="-63.5224609375" sy="-11.25" tx="-50.81796875" ty="-15.0">
-            <y:Point x="53.00032862103174" y="385.0625"/>
-            <y:Point x="53.00032862103174" y="346.828125"/>
-            <y:Point x="141.67806299603174" y="346.828125"/>
+          <y:Path sx="-63.1162109375" sy="-12.0" tx="-52.935384114583336" ty="-15.0">
+            <y:Point x="69.50015336294024" y="415.34515380859375"/>
+            <y:Point x="69.50015336294024" y="366.5101318359375"/>
+            <y:Point x="113.06779048859127" y="366.5101318359375"/>
           </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="68.177734375" x="-65.97324315631202" y="-47.21875">e_HasNext<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="64.00302124023438" x="-22.980559527684775" y="-48.83502197265625">e_HasNext<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:QuadCurveEdge>
       </data>
@@ -102,14 +102,14 @@
     <edge id="e3" source="n2" target="n2">
       <data key="d10">
         <y:QuadCurveEdge straightness="0.1">
-          <y:Path sx="-63.5224609375" sy="-3.75" tx="-25.408984375000003" ty="-15.0">
-            <y:Point x="37.00032862103174" y="392.5625"/>
-            <y:Point x="37.00032862103174" y="292.859375"/>
-            <y:Point x="167.08704737103176" y="292.859375"/>
+          <y:Path sx="-63.5224609375" sy="-6.0" tx="-31.76123046875" ty="-15.0">
+            <y:Point x="53.50015336294024" y="421.34515380859375"/>
+            <y:Point x="53.50015336294024" y="320.17510986328125"/>
+            <y:Point x="134.2419441344246" y="320.17510986328125"/>
           </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="66.935546875" x="-81.9238504561167" y="-108.6875">e_GetNext<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="62.467864990234375" x="-38.980559527684775" y="-101.1700439453125">e_GetNext<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:QuadCurveEdge>
       </data>
@@ -117,32 +117,46 @@
     <edge id="e4" source="n2" target="n2">
       <data key="d10">
         <y:QuadCurveEdge straightness="0.1">
-          <y:Path sx="-63.5224609375" sy="3.75" tx="0.0" ty="-15.0">
-            <y:Point x="21.00032862103174" y="400.0625"/>
-            <y:Point x="21.00032862103174" y="238.890625"/>
-            <y:Point x="192.49603174603175" y="238.890625"/>
+          <y:Path sx="-63.5224609375" sy="0.0" tx="-10.587076822916664" ty="-15.0">
+            <y:Point x="37.50015336294024" y="427.34515380859375"/>
+            <y:Point x="37.50015336294024" y="273.840087890625"/>
+            <y:Point x="155.41609778025796" y="273.840087890625"/>
           </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="67.421875" x="-97.94425145709323" y="-170.15625000000003">e_GetData<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="62.45587158203125" x="-54.98055952768483" y="-153.50506591796875">e_GetData<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:QuadCurveEdge>
       </data>
     </edge>
     <edge id="e5" source="n2" target="n2">
-      <data key="d9"/>
       <data key="d10">
         <y:BezierEdge>
-          <y:Path sx="-63.5224609375" sy="11.25" tx="25.408984375000003" ty="-15.0">
-            <y:Point x="5.000328621031741" y="407.5625"/>
-            <y:Point x="5.000328621031741" y="184.921875"/>
-            <y:Point x="217.90501612103174" y="184.921875"/>
+          <y:Path sx="-63.5224609375" sy="6.0" tx="10.587076822916671" ty="-15.0">
+            <y:Point x="21.50015336294024" y="433.34515380859375"/>
+            <y:Point x="21.50015336294024" y="227.50506591796875"/>
+            <y:Point x="176.5902514260913" y="227.50506591796875"/>
           </y:Path>
           <y:LineStyle color="#000000" type="line" width="1.0"/>
           <y:Arrows source="none" target="standard"/>
-          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="17.96875" modelName="free" modelPosition="anywhere" preferredPlacement="anywhere" ratio="0.5" textColor="#000000" visible="true" width="96.9296875" x="-113.97324315631194" y="-231.62500000000003">e_StartMachine<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" frozen="true" placement="anywhere" side="anywhere" sideReference="relative_to_edge_flow"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="91.06015014648438" x="-70.98055952768482" y="-205.840087890625">e_StartMachine<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
           </y:EdgeLabel>
         </y:BezierEdge>
+      </data>
+    </edge>
+    <edge id="e6" source="n2" target="n2">
+      <data key="d10">
+        <y:QuadCurveEdge straightness="0.1">
+          <y:Path sx="-63.1162109375" sy="12.0" tx="31.76123046875" ty="-15.0">
+            <y:Point x="5.500153362940239" y="439.34515380859375"/>
+            <y:Point x="5.500153362940239" y="181.1700439453125"/>
+            <y:Point x="197.7644050719246" y="181.1700439453125"/>
+          </y:Path>
+          <y:LineStyle color="#000000" type="line" width="1.0"/>
+          <y:Arrows source="none" target="standard"/>
+          <y:EdgeLabel alignment="center" configuration="AutoFlippingLabel" distance="2.0" fontFamily="Dialog" fontSize="12" fontStyle="plain" hasBackgroundColor="false" hasLineColor="false" height="20.33502197265625" horizontalTextPosition="center" iconTextGap="4" modelName="free" modelPosition="anywhere" preferredPlacement="right" ratio="0.5" textColor="#000000" verticalTextPosition="bottom" visible="true" width="60.309051513671875" x="-86.98055952768476" y="-258.17510986328125">e_SetData<y:PreferredPlacementDescriptor angle="0.0" angleOffsetOnRightSide="0" angleReference="absolute" angleRotationOnRightSide="co" distance="-1.0" placement="anywhere" side="right" sideReference="relative_to_edge_flow"/>
+          </y:EdgeLabel>
+        </y:QuadCurveEdge>
       </data>
     </edge>
   </graph>


### PR DESCRIPTION
This PR adds `setData`to the websocket API.

An example of calling `setData`
```
{
  command:"setData",
  action: "some_data = 1425"
}
```

See also the updated test in this PR.

Background: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/graphwalker/7GRI42PMueI/cN1ozfJKAwAJ