### PR TITLE
Websocket: included modelName in getNext response, critical requirement for multimodel implementation through websocket

### DIFF
--- a/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
+++ b/graphwalker-websocket/src/main/java/org/graphwalker/websocket/WebSocketServer.java
@@ -182,6 +182,7 @@ public class WebSocketServer extends org.java_websocket.server.WebSocketServer i
             response.put("modelId", machine.getCurrentContext().getModel().getId());
             response.put("elementId", machine.getCurrentContext().getCurrentElement().getId());
             response.put("name", machine.getCurrentContext().getCurrentElement().getName());
+            response.put("modelName", machine.getCurrentContext().getModel().getName());
             response.put("success", true);
           } catch (Exception e) {
             logger.error(e.getMessage());


### PR DESCRIPTION
added modelName in response object of Websocket getNext command

it is a critical requirement for multi-model implementation through WebSocket where we need model Name also to call the required function inside the Model's class