### PR TITLE
Fix for issue 238

### DIFF
--- a/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/dot/DOT.g4
+++ b/graphwalker-dsl/src/main/antlr4/org/graphwalker/dsl/dot/DOT.g4
@@ -2,7 +2,6 @@
  [The "BSD licence"]
  Copyright (c) 2013 Terence Parr
  All rights reserved.
-
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
@@ -13,7 +12,6 @@
     documentation and/or other materials provided with the distribution.
  3. The name of the author may not be used to endorse or promote products
     derived from this software without specific prior written permission.
-
  THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -25,73 +23,156 @@
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-
 /** Derived from http://www.graphviz.org/doc/info/lang.html.
     Comments pulled from spec.
  */
 grammar DOT;
 
-graph       :   STRICT? (GRAPH | DIGRAPH) id? '{' stmt_list '}' ;
-stmt_list   :   ( stmt ';'? )* ;
-stmt        :   node_stmt
-            |   edge_stmt
-            |   attr_stmt
-            |   id '=' id
-            |   subgraph
-            ;
-attr_stmt   :   (GRAPH | NODE | EDGE) attr_list ;
-attr_list   :   ('[' a_list? ']')+ ;
-a_list      :   (id ('=' id)? ','?)+ ;
-edge_stmt   :   (node_id | subgraph) edgeRHS attr_list? ;
-edgeRHS     :   ( edgeop (node_id | subgraph) )+ ;
-edgeop      :   '->' | '--' ;
-node_stmt   :   node_id attr_list? ;
-node_id     :   id port? ;
-port        :   ':' id (':' id)? ;
-subgraph    :   (SUBGRAPH id?)? '{' stmt_list '}' ;
-id          :   ID
-            |   STRING
-            |   HTML_STRING
-            |   NUMBER
-            ;
+graph
+   : STRICT? ( GRAPH | DIGRAPH ) id? '{' stmt_list '}'
+   ;
+
+stmt_list
+   : ( stmt ';'? )*
+   ;
+
+stmt
+   : node_stmt | edge_stmt | attr_stmt | id '=' id | subgraph
+   ;
+
+attr_stmt
+   : ( GRAPH | NODE | EDGE ) attr_list
+   ;
+
+attr_list
+   : ( '[' a_list? ']' )+
+   ;
+
+a_list
+   : ( id ( '=' id )? ','? )+
+   ;
+
+edge_stmt
+   : ( node_id | subgraph ) edgeRHS attr_list?
+   ;
+
+edgeRHS
+   : ( edgeop ( node_id | subgraph ) )+
+   ;
+
+edgeop
+   : '->' | '--'
+   ;
+
+node_stmt
+   : node_id attr_list?
+   ;
+
+node_id
+   : id port?
+   ;
+
+port
+   : ':' id ( ':' id )?
+   ;
+
+subgraph
+   : ( SUBGRAPH id? )? '{' stmt_list '}'
+   ;
+
+id
+   : ID | STRING | HTML_STRING | NUMBER
+   ;
 
 // "The keywords node, edge, graph, digraph, subgraph, and strict are
 // case-independent"
-STRICT      :   [Ss][Tt][Rr][Ii][Cc][Tt] ;
-GRAPH       :   [Gg][Rr][Aa][Pp][Hh] ;
-DIGRAPH     :   [Dd][Ii][Gg][Rr][Aa][Pp][Hh] ;
-NODE        :   [Nn][Oo][Dd][Ee] ;
-EDGE        :   [Ee][Dd][Gg][Ee] ;
-SUBGRAPH    :   [Ss][Uu][Bb][Gg][Rr][Aa][Pp][Hh] ;
 
-/** "a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? )" */
-NUMBER      :   '-'? ('.' DIGIT+ | DIGIT+ ('.' DIGIT*)? ) ;
-fragment
-DIGIT       :   [0-9] ;
+STRICT
+   : [Ss] [Tt] [Rr] [Ii] [Cc] [Tt]
+   ;
 
-/** "any double-quoted string ("...") possibly containing escaped quotes" */
-STRING      :   '"' ('\\"'|.)*? '"' ;
+
+GRAPH
+   : [Gg] [Rr] [Aa] [Pp] [Hh]
+   ;
+
+
+DIGRAPH
+   : [Dd] [Ii] [Gg] [Rr] [Aa] [Pp] [Hh]
+   ;
+
+
+NODE
+   : [Nn] [Oo] [Dd] [Ee]
+   ;
+
+
+EDGE
+   : [Ee] [Dd] [Gg] [Ee]
+   ;
+
+
+SUBGRAPH
+   : [Ss] [Uu] [Bb] [Gg] [Rr] [Aa] [Pp] [Hh]
+   ;
+
+
+/** "a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? )" */ NUMBER
+   : '-'? ( '.' DIGIT+ | DIGIT+ ( '.' DIGIT* )? )
+   ;
+
+
+fragment DIGIT
+   : [0-9]
+   ;
+
+
+/** "any double-quoted string ("...") possibly containing escaped quotes" */ STRING
+   : '"' ( '\\"' | . )*? '"'
+   ;
+
 
 /** "Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores
  *  ('_') or digits ([0-9]), not beginning with a digit"
- */
-ID          :   LETTER (LETTER|DIGIT)*;
-fragment
-LETTER      :   [a-zA-Z\u0080-\u00FF_] ;
+ */ ID
+   : LETTER ( LETTER | DIGIT )*
+   ;
+
+
+fragment LETTER
+   : [a-zA-Z\u0080-\u00FF_]
+   ;
+
 
 /** "HTML strings, angle brackets must occur in matched pairs, and
  *  unescaped newlines are allowed."
- */
-HTML_STRING :   '<' (TAG|~[<>])* '>' ;
-fragment
-TAG         :   '<' .*? '>' ;
+ */ HTML_STRING
+   : '<' ( TAG | ~ [<>] )* '>'
+   ;
 
-COMMENT     :   '/*' .*? '*/'       -> skip ;
-LINE_COMMENT:   '//' .*? '\r'? '\n' -> skip ;
+
+fragment TAG
+   : '<' .*? '>'
+   ;
+
+
+COMMENT
+   : '/*' .*? '*/' -> skip
+   ;
+
+
+LINE_COMMENT
+   : '//' .*? '\r'? '\n' -> skip
+   ;
+
 
 /** "a '#' character is considered a line output from a C preprocessor (e.g.,
  *  # 34 to indicate line 34 ) and discarded"
- */
-PREPROC     :   '#' .*? '\n' -> skip ;
+ */ PREPROC
+   : '#' ~[\r\n]* -> skip
+   ;
 
-WS          :   [ \t\n\r]+ -> skip ;
+
+WS
+   : [ \t\n\r]+ -> skip
+   ;

--- a/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/dot/DotModelListener.java
+++ b/graphwalker-dsl/src/main/java/org/graphwalker/dsl/antlr/dot/DotModelListener.java
@@ -20,6 +20,7 @@ public class DotModelListener extends DOTBaseListener {
   }
 
   private Vertex createVertex(String id, String label) {
+    id = id.replaceAll("^\"|\"$", "");
     if ("Start".equalsIgnoreCase(id) || "Start".equalsIgnoreCase(label)) {
       vertices.put(id, null);
       return null;

--- a/graphwalker-io/src/main/java/org/graphwalker/io/factory/dot/DotContextFactory.java
+++ b/graphwalker-io/src/main/java/org/graphwalker/io/factory/dot/DotContextFactory.java
@@ -104,33 +104,6 @@ public final class DotContextFactory implements ContextFactory {
         .filter(edge -> edge.getSourceVertex() == null)
         .forEach(context::setNextElement);
       context.setModel(model.build());
-      /*
-      Edge startEdge = null;
-      for (Vertex vertex : listener.getVertices().values()) {
-        if (!"START".equalsIgnoreCase(vertex.getName())) {
-          model.addVertex(vertex);
-        }
-      }
-      for (Edge edge : listener.getEdges()) {
-        if (edge.getSourceVertex() != null && "START".equalsIgnoreCase(edge.getSourceVertex().getName())) {
-          edge.setSourceVertex(null);
-          startEdge = edge;
-        }
-        model.addEdge(edge);
-      }
-
-      model.setName(FilenameUtils.removeExtension(path.getFileName().toString()));
-      context.setModel(model.build());
-      if (null != startEdge) {
-        context.setNextElement(startEdge);
-      } else {
-        for (Vertex.RuntimeVertex vertex : context.getModel().getVertices()) {
-          if (context.getModel().getOutEdges(vertex).isEmpty()) {
-            context.setNextElement(vertex);
-          }
-        }
-      }
-      */
     } catch (IOException e) {
       logger.error(e.getMessage());
       throw new ContextFactoryException("Could not read the file.");

--- a/graphwalker-io/src/test/java/org/graphwalker/io/factory/dot/DotContextFactoryTest.java
+++ b/graphwalker-io/src/test/java/org/graphwalker/io/factory/dot/DotContextFactoryTest.java
@@ -164,4 +164,18 @@ public class DotContextFactoryTest {
     assertThat(context.getModel().getVertices().size(), is(3));
     assertThat(context.getModel().getEdges().size(), is(9));
   }
+
+  @Test
+  public void doubleQuote() throws IOException {
+    List<Context> contexts = new DotContextFactory().create(Paths.get("dot/doubleQuote.dot"));
+    assertNotNull(contexts);
+    assertThat(contexts.size(), is(1));
+    Context context = contexts.get(0);
+    assertThat(context.getModel().getVertices().size(), is(2));
+    assertThat(context.getModel().getEdges().size(), is(0));
+    assertThat(context.getModel().getVertices().get(0).getName(), is("v1"));
+    assertThat(context.getModel().getVertices().get(1).getName(), is("v2"));
+    assertThat(context.getModel().getVertices().get(0).getId(), is("n1"));
+    assertThat(context.getModel().getVertices().get(1).getId(), is("n2"));
+  }
 }

--- a/graphwalker-io/src/test/resources/dot/doubleQuote.dot
+++ b/graphwalker-io/src/test/resources/dot/doubleQuote.dot
@@ -1,0 +1,4 @@
+digraph DoubleQuote {
+    "n1" [label="v1"]
+    n2   [label=v2]
+}


### PR DESCRIPTION
When an id is read from a dot file, and it's quoted, trimming of any preceding or trailing double quotes should be removed.