### PR TITLE
Implement load and save of Profiler

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/statistics/SimpleProfiler.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/statistics/SimpleProfiler.java
@@ -200,4 +200,21 @@ public class SimpleProfiler implements Profiler {
   public Profile getProfile(Context context, Element element) {
     return new Profile(context, element, executions.get(context).get(element));
   }
+
+  public static SimpleProfiler createFromExecutionPath(List<Execution> executionPath) {
+    SimpleProfiler profiler = new SimpleProfiler();
+    for (Execution execution : executionPath) {
+      Context context = execution.getContext();
+      if (!profiler.executions.containsKey(context)) {
+        profiler.executions.put(context, new HashMap<>());
+      }
+      Element element = execution.getElement();
+      if (!profiler.executions.get(context).containsKey(element)) {
+        profiler.executions.get(context).put(element, new ArrayList<>());
+      }
+      profiler.executionPath.add(execution);
+      profiler.executions.get(context).get(element).add(execution);
+    }
+    return profiler;
+  }
 }

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/ReplayMachineTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/ReplayMachineTest.java
@@ -27,14 +27,18 @@ package org.graphwalker.core.machine;
  */
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 import org.graphwalker.core.condition.EdgeCoverage;
 import org.graphwalker.core.generator.RandomPath;
 import org.graphwalker.core.model.*;
 import org.graphwalker.core.statistics.Execution;
+import org.graphwalker.core.statistics.SimpleProfiler;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,6 +59,37 @@ public class ReplayMachineTest {
     List<Element> replayedPath = replayMachine.getProfiler().getExecutionPath().stream()
       .map(Execution::getElement).collect(Collectors.toList());
     assertThat(replayedPath, is(expectedPath));
+  }
+
+  @Test
+  public void replayMachineFromExecutionPath() {
+    Machine machine = createMachineExecution();
+    List<Execution> executionPath = new ArrayList<>(machine.getProfiler().getExecutionPath());
+    Machine replayMachine = new ReplayMachine(SimpleProfiler.createFromExecutionPath(executionPath));
+    while (replayMachine.hasNextStep()) {
+      replayMachine.getNextStep();
+    }
+    List<Element> expectedPath = machine.getProfiler().getExecutionPath().stream()
+      .map(Execution::getElement).collect(Collectors.toList());
+    List<Element> replayedPath = replayMachine.getProfiler().getExecutionPath().stream()
+      .map(Execution::getElement).collect(Collectors.toList());
+    assertEquals(expectedPath, replayedPath);
+  }
+
+  @Test
+  public void replayMachineFromAlteredExecutionPath() {
+    Machine machine = createMachineExecution();
+    List<Execution> executionPath = new ArrayList<>(machine.getProfiler().getExecutionPath());
+    executionPath.remove(executionPath.size() - 1);
+    Machine replayMachine = new ReplayMachine(SimpleProfiler.createFromExecutionPath(executionPath));
+    while (replayMachine.hasNextStep()) {
+      replayMachine.getNextStep();
+    }
+    List<Element> originalPath = machine.getProfiler().getExecutionPath().stream()
+      .map(Execution::getElement).collect(Collectors.toList());
+    List<Element> replayedPath = replayMachine.getProfiler().getExecutionPath().stream()
+      .map(Execution::getElement).collect(Collectors.toList());
+    assertNotEquals(originalPath, replayedPath);
   }
 
   private Machine createMachineExecution() {


### PR DESCRIPTION
Implementing load and save of Profiler is a step towards achieving test execution playback. The latter is what I want to achieve with GraphWalker, as I discussed in [this Google Groups message](https://groups.google.com/g/graphwalker/c/qR8ZmBfltfg/m/qYp1Q1voBgAJ).

I intend to implement the first story mentioned in [the first response](https://groups.google.com/g/graphwalker/c/qR8ZmBfltfg/m/ySeIgQnBBwAJ) to the previously mentioned message (or at least attempt to do so) as part of this PR.
> 1 - Make a Profiler that can ingest a previous execution.

This PR is currently a work-in-progress draft in a very early stage. As I already have some (little) code to show and ask feedback for, I thought I might as well create this PR.