### PR TITLE
Fix issue with accessing global attributes

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
@@ -273,7 +273,13 @@ public abstract class ExecutionContext implements Context {
   }
 
   public Value getAttribute(String name) {
-    return executionEnvironment.getBindings("js").getMember(name);
+    Pattern pattern = Pattern.compile(REGEXP_GLOBAL);
+    Matcher matcher = pattern.matcher(name);
+    if (matcher.find()) {
+      return globalExecutionEnvironment.getBindings("js").getMember(name.replaceAll(REGEXP_GLOBAL, ""));
+    } else {
+      return executionEnvironment.getBindings("js").getMember(name);
+    }
   }
 
   public void setAttribute(String name, Value value) {
@@ -283,10 +289,21 @@ public abstract class ExecutionContext implements Context {
   public String data() {
     StringBuilder data = new StringBuilder();
     for (String member : executionEnvironment.getBindings("js").getMemberKeys()) {
+      if (executionEnvironment.getBindings("js").getMember(member).toString().contains("org.graphwalker.core.machine.TestExecutionContext")) {
+        continue;
+      }
       data.append(member)
         .append(": ")
         .append(executionEnvironment.getBindings("js").getMember(member))
         .append(", ");
+    }
+    if (isNotNull(globalExecutionEnvironment)) {
+      for (String member : globalExecutionEnvironment.getBindings("js").getMemberKeys()) {
+        data.append("global." + member)
+          .append(": ")
+          .append(globalExecutionEnvironment.getBindings("js").getMember(member))
+          .append(", ");
+      }
     }
     return data.toString();
   }

--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/SimpleMachine.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/SimpleMachine.java
@@ -37,11 +37,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.graphwalker.core.common.Objects.isNotNull;
-import static org.graphwalker.core.common.Objects.isNull;
+import static org.graphwalker.core.common.Objects.*;
 import static org.graphwalker.core.model.Edge.RuntimeEdge;
 import static org.graphwalker.core.model.Vertex.RuntimeVertex;
 
@@ -292,15 +289,7 @@ public class SimpleMachine extends MachineBase {
   }
 
   private void execute(Action action) {
-    Pattern pattern = Pattern.compile(REGEXP_GLOBAL);
-    Matcher matcher = pattern.matcher(action.getScript());
-
-    if (matcher.find()) {
-      LOG.debug("Execute action: '{}' in model: '{}'", action.getScript(), getCurrentContext().getModel().getName());
-      globalExecutionEnvironment.eval("js", action.getScript().replaceAll(REGEXP_GLOBAL, ""));
-    } else {
-      getCurrentContext().execute(action);
-    }
+     getCurrentContext().execute(action);
   }
 
   private static class SharedStateTuple {

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/SharedStateTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/SharedStateTest.java
@@ -152,7 +152,9 @@ public class SharedStateTest {
           .setSharedState("SHARED_STATE_VERTEX")
         )
       )
-      .addAction(new Action("global.myVariable = false; global.myVariable_2 = false;"));
+      .addAction(new Action("myVariable = true;"))
+      .addAction(new Action("global.myVariable = false"))
+      .addAction(new Action("global.myVariable_2 = false;"));
 
     // Model 2 has 2 vertices and 2 edges. One edge, e_C performs an action which has to execute in order
     // to fulfill the condition for edge e_D
@@ -186,16 +188,21 @@ public class SharedStateTest {
     List<String> actualPath = new ArrayList<String>();
     while (machine.hasNextStep()) {
       machine.getNextStep();
-      actualPath.add(machine.getCurrentContext().getCurrentElement().getName());
+      actualPath.add(machine.getCurrentContext().getCurrentElement().getName()
+        + ": " + machine.getCurrentContext().getAttribute("myVariable")
+        + ", " + machine.getCurrentContext().getAttribute("global.myVariable")
+        + ", " + machine.getCurrentContext().getAttribute("global.myVariable_2")
+        + ", data: " + ((ExecutionContext)machine.getCurrentContext()).data()
+      );
     }
     Assert.assertArrayEquals(new ArrayList<>(Arrays.asList(
-      "v_A",
-      "e_B",
-      "v_B",
-      "v_C",
-      "e_C",
-      "v_C",
-      "e_D",
-      "v_D"
+      "v_A: true, false, false, data: myVariable: true, global.myVariable: false, global.myVariable_2: false, ",
+      "e_B: true, false, false, data: myVariable: true, global.myVariable: false, global.myVariable_2: false, ",
+      "v_B: true, false, false, data: myVariable: true, global.myVariable: false, global.myVariable_2: false, ",
+      "v_C: null, false, false, data: global.myVariable: false, global.myVariable_2: false, ",
+      "e_C: null, true, false, data: global.myVariable: true, global.myVariable_2: false, ",
+      "v_C: null, true, false, data: global.myVariable: true, global.myVariable_2: false, ",
+      "e_D: null, true, false, data: global.myVariable: true, global.myVariable_2: false, ",
+      "v_D: null, true, false, data: global.myVariable: true, global.myVariable_2: false, "
     )).toArray(), actualPath.toArray());  }
 }


### PR DESCRIPTION
A fix for accessing global attributes

From the graphwalker forum: https://groups.google.com/g/graphwalker/c/o5y1_iE7F-o/m/Z9cg5OwZCQAJ

```
I'm prefixing my global variables with "global." and yet I'm unable to access them in other model implementation Java classes.
I get an error like this:
java.lang.NullPointerException: Cannot invoke "org.graalvm.polyglot.Value.asString()" because the return value of "com.example.modelimplementations.SecondViewTest.getAttribute(String)" is null

I added a commit to my graphwalker-problem GitHub repository that demonstrates this problem in code.
```