### PR TITLE
Fix error when trying to execute multi-model ReplayMachine

### DIFF
--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/ReplayMachine.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/ReplayMachine.java
@@ -28,6 +28,7 @@ package org.graphwalker.core.machine;
 
 import org.graphwalker.core.statistics.Execution;
 import org.graphwalker.core.statistics.Profiler;
+import org.graphwalker.core.statistics.SimpleProfiler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,6 +82,8 @@ public class ReplayMachine extends SimpleMachine {
       try {
         Context newContext = context.getClass().newInstance();
         newContext.setModel(context.getModel());
+        newContext.setPathGenerator(context.getPathGenerator());
+        newContext.setProfiler(new SimpleProfiler());
         contexts.put(context, newContext);
       } catch (InstantiationException | IllegalAccessException e) {
         LOG.error(e.getMessage());

--- a/graphwalker-core/src/test/java/org/graphwalker/core/machine/ReplayMachineTest.java
+++ b/graphwalker-core/src/test/java/org/graphwalker/core/machine/ReplayMachineTest.java
@@ -45,7 +45,15 @@ public class ReplayMachineTest {
 
   @Test
   public void replayMachine() throws Exception {
-    Machine machine = createMachineExecution();
+    compareMachineWithReplayMachine(createMachineExecution());
+  }
+
+  @Test
+  public void replayMultiModelMachine() throws Exception {
+    compareMachineWithReplayMachine(createMultiModelMachineExecution());
+  }
+
+  private void compareMachineWithReplayMachine(Machine machine) {
     Machine replayMachine = new ReplayMachine(machine.getProfiler());
     while (replayMachine.hasNextStep()) {
       replayMachine.getNextStep();
@@ -65,6 +73,31 @@ public class ReplayMachineTest {
     Context context = new TestExecutionContext(model, new RandomPath(new EdgeCoverage(100)));
     context.setNextElement(vertex);
     Machine machine = new SimpleMachine(context);
+    while (machine.hasNextStep()) {
+      machine.getNextStep();
+    }
+    return machine;
+  }
+
+  private Machine createMultiModelMachineExecution() {
+    Vertex vertex1 = new Vertex();
+    vertex1.setName("vertex1");
+    vertex1.setSharedState("sharedState");
+    Edge edge1a = new Edge().setSourceVertex(vertex1).setTargetVertex(vertex1).addAction(new Action("flag = true;")).setName("edge1a");
+    Edge edge1b = new Edge().setSourceVertex(vertex1).setTargetVertex(vertex1).setGuard(new Guard("flag === true")).setName("edge1b");
+    Model model1 = new Model().addEdge(edge1a).addEdge(edge1b).addAction(new Action("var flag = false;"));
+    Context context1 = new TestExecutionContext(model1, new RandomPath(new EdgeCoverage(100)));
+    context1.setNextElement(vertex1);
+
+    Vertex vertex2 = new Vertex();
+    vertex2.setName("vertex2");
+    vertex2.setSharedState("sharedState");
+    Edge edge2a = new Edge().setSourceVertex(vertex2).setTargetVertex(vertex2).addAction(new Action("flag = true;")).setName("edge2a");
+    Edge edge2b = new Edge().setSourceVertex(vertex2).setTargetVertex(vertex2).setGuard(new Guard("flag === true")).setName("edge2b");
+    Model model2 = new Model().addEdge(edge2a).addEdge(edge2b).addAction(new Action("var flag = false;"));
+    Context context2 = new TestExecutionContext(model2, new RandomPath(new EdgeCoverage(100)));
+
+    Machine machine = new SimpleMachine(context1, context2);
     while (machine.hasNextStep()) {
       machine.getNextStep();
     }


### PR DESCRIPTION
Executing a ReplayMachine created from a multi-model machine ran into the following error as soon as the execution left the first model (output from executing replayMultiModelMachine without the fix):
```
[main] ERROR o.g.core.machine.SimpleMachine.walk - No path generator is defined

org.graphwalker.core.machine.MachineException: org.graphwalker.core.machine.MachineException: No path generator is defined

	at org.graphwalker.core.machine.SimpleMachine.walk(SimpleMachine.java:147)
	at org.graphwalker.core.machine.SimpleMachine.getNextStep(SimpleMachine.java:102)
	at org.graphwalker.core.machine.ReplayMachineTest.compareMachineWithReplayMachine(ReplayMachineTest.java:59)
	at org.graphwalker.core.machine.ReplayMachineTest.replayMultiModelMachine(ReplayMachineTest.java:53)
        ...
Caused by: org.graphwalker.core.machine.MachineException: No path generator is defined
	at org.graphwalker.core.machine.SimpleMachine.hasNextStep(SimpleMachine.java:270)
	at org.graphwalker.core.machine.SimpleMachine.switchContext(SimpleMachine.java:179)
	at org.graphwalker.core.machine.SimpleMachine.chooseSharedContext(SimpleMachine.java:201)
	at org.graphwalker.core.machine.SimpleMachine.takeNextStep(SimpleMachine.java:190)
	at org.graphwalker.core.machine.SimpleMachine.walk(SimpleMachine.java:140)
	... 28 more
```

This commit contains a test demonstrating the issue and my fix for it, each in its own commit.