### PR TITLE
Use getRootCause to un-obscure root cause exception.

### DIFF
--- a/graphwalker-core/pom.xml
+++ b/graphwalker-core/pom.xml
@@ -37,6 +37,10 @@
       <groupId>org.graalvm.truffle</groupId>
       <artifactId>truffle-api</artifactId>
     </dependency>
-    </dependencies>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+      </dependency>
+  </dependencies>
 
 </project>

--- a/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
+++ b/graphwalker-core/src/main/java/org/graphwalker/core/machine/ExecutionContext.java
@@ -26,6 +26,7 @@ package org.graphwalker.core.machine;
  * #L%
  */
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.graalvm.polyglot.Value;
 import org.graphwalker.core.algorithm.Algorithm;
 import org.graphwalker.core.generator.PathGenerator;
@@ -279,7 +280,9 @@ public abstract class ExecutionContext implements Context {
     } catch (Throwable t) {
       executionStatus = ExecutionStatus.FAILED;
       LOG.error(t.getMessage());
-      throw new MachineException(this, t);
+      // Do not obscure the root cause as it's not useful for the end user
+      // i.e: always showing java.lang.reflect.InvocationTargetException no matter what.
+      throw new MachineException(this, ExceptionUtils.getRootCause(t));
     }
   }
 

--- a/graphwalker-java/src/test/java/org/graphwalker/java/test/TestExecutorTest.java
+++ b/graphwalker-java/src/test/java/org/graphwalker/java/test/TestExecutorTest.java
@@ -34,6 +34,7 @@ import org.graphwalker.core.model.Vertex;
 import org.graphwalker.core.statistics.Execution;
 import org.graphwalker.io.factory.json.JsonContextFactory;
 import org.graphwalker.java.annotation.GraphWalker;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -192,6 +193,28 @@ public class TestExecutorTest {
   public void throwExceptionExecutor() throws IOException {
     Executor executor = new TestExecutor(ThrowExceptionTest.class);
     executor.execute();
+  }
+
+  /**
+   * Do not obscure the root cause
+   * @throws IOException
+   */
+  @Test
+  public void doNotHideRootCauseException() throws IOException {
+    Executor executor = new TestExecutor(ThrowExceptionTest.class);
+
+    Result result = executor.execute(true);
+    Assert.assertTrue(result.hasErrors());
+    JSONArray failures = (JSONArray) result.getResults().get("failures");
+    ArrayList<String> failureList = new ArrayList<>();
+    failures.forEach( failure -> {
+      Boolean hasFailureItem = ((JSONObject) failure).has("failure");
+      if (hasFailureItem) {
+        failureList.add(((JSONObject) failure).getString("failure"));
+      }
+    } );
+
+    Assert.assertTrue(failureList.get(0).startsWith("java.lang.RuntimeException"));
   }
 
   @Test


### PR DESCRIPTION
When automation test fail, graphwalker will always show: `java.lang.reflect.InvocationTargetException`. This makes debugging difficult as we have to rely on log message to see where the code fail -- often with guessing.

This small PR will attach the root cause instead of graphwalker local exception.

Given the following implementation:
![image](https://user-images.githubusercontent.com/8678/193487268-88b83d9e-890c-453e-bf53-a80bffc1b6a8.png)


Before:
```
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.graphwalker.core.machine.ExecutionContext.execute(ExecutionContext.java:277)
```

After:
```
java.lang.RuntimeException
	at org.graphwalker.java.test.TestExecutorTest$ThrowExceptionTest.throwException(TestExecutorTest.java:188)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.graphwalker.core.machine.ExecutionContext.execute(ExecutionContext.java:277)
```