### PR TITLE
Updating library dependnecies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,22 +171,22 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.16.1</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20231013</version>
+        <version>20240303</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.26</version>
+        <version>2.0.13</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.13</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.132</version>
+        <version>4.8.174</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.javaparser</groupId>
@@ -216,12 +216,12 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.81</version>
+        <version>1.82</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
+        <version>3.14.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -231,17 +231,17 @@
       <dependency>
         <groupId>org.java-websocket</groupId>
         <artifactId>Java-WebSocket</artifactId>
-        <version>1.5.2</version>
+        <version>1.5.6</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.8.9</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.0.0-jre</version>
+        <version>33.2.1-jre</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -261,13 +261,13 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
+        <version>4.5.14</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.xmlunit</groupId>
         <artifactId>xmlunit-matchers</artifactId>
-        <version>2.8.3</version>
+        <version>2.10.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -289,12 +289,12 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>3.6.1</version>
+        <version>3.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
-        <version>1.5.0</version>
+        <version>1.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
@@ -314,8 +314,7 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.28.0-GA</version>
-      </dependency>
+        <version>3.30.2-GA</version> </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Some dependencies could not be updated to latest bc breaking changes. Only non-breaking [compile] updates.
Following dependencies are not updated:
```
./mvnw clean versions:display-dependency-updates
:
[INFO] The following dependencies in Dependency Management have newer versions:
[INFO]   com.sun.xml.bind:jaxb-core .......................... 2.3.0.1 -> 4.0.5
[INFO]   com.sun.xml.bind:jaxb-impl ............................ 2.3.1 -> 4.0.5
[INFO]   org.apache.maven:maven-core .................... 3.8.3 -> 4.0.0-beta-3
[INFO]   org.apache.maven:maven-plugin-api .............. 3.8.3 -> 4.0.0-beta-3
[INFO]   org.apache.xmlbeans:xmlbeans .......................... 3.1.0 -> 5.2.1
[INFO]   org.graalvm.js:js ................................... 22.3.5 -> 23.0.4
[INFO]   org.graalvm.js:js-scriptengine ...................... 22.3.5 -> 24.0.1
[INFO]   org.graalvm.sdk:graal-sdk ........................... 22.3.5 -> 24.0.1
[INFO]   org.graalvm.truffle:truffle-api ..................... 22.3.5 -> 24.0.1
[INFO]   org.slf4j:slf4j-api ........................... 2.0.13 -> 2.1.0-alpha1
[INFO]   org.springframework.boot:spring-boot-starter-actuator ...
[INFO]                                                           2.7.9 -> 3.3.0
[INFO]   org.springframework.boot:spring-boot-starter-tomcat ... 2.7.9 -> 3.3.0
[INFO]   org.springframework.boot:spring-boot-starter-web ...... 2.7.9 -> 3.3.0
[INFO] 
[INFO] The following dependencies in Dependencies have newer versions:
[INFO]   org.slf4j:slf4j-api ........................... 2.0.13 -> 2.1.0-alpha1
:
```