### PR TITLE
Fix for NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder

### DIFF
--- a/graphwalker-studio/src/main/java/org/graphwalker/studio/Application.java
+++ b/graphwalker-studio/src/main/java/org/graphwalker/studio/Application.java
@@ -28,6 +28,7 @@ public class Application {
   private static final Logger logger = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args) throws UnknownHostException {
+    System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
     Application app = new Application();
     try {
       app.run(args);


### PR DESCRIPTION
When starting Studio it fails loading org/slf4j/impl/StaticLoggerBinder due to chaneges in sping from version 2.7.8

See:
* https://github.com/spring-projects/spring-boot/issues/12649#issuecomment-2086678117
* https://docs.spring.io/spring-boot/docs/2.7.8/reference/html/features.html#features.logging