### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,7 +44,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -55,7 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -69,4 +69,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Setup Java JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: 17
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/ubuntu_java-17.yml
+++ b/.github/workflows/ubuntu_java-17.yml
@@ -1,4 +1,4 @@
-name: Build and test on latest Windows and Java 11
+name: Build and test on latest Ubuntu and Java 11
 
 on:
   push:
@@ -11,17 +11,14 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
-    - name: Grant execute permission for mvnw
-      run: chmod +x mvnw
     - name: Build with Maven
-      run: ./mvnw -B package --file pom.xml
-
+      run: mvn -B package --file pom.xml

--- a/.github/workflows/ubuntu_java-17.yml
+++ b/.github/workflows/ubuntu_java-17.yml
@@ -1,4 +1,4 @@
-name: Build and test on latest Ubuntu and Java 11
+name: Build and test on latest Ubuntu and Java 17
 
 on:
   push:

--- a/.github/workflows/windows_java-17.yml
+++ b/.github/workflows/windows_java-17.yml
@@ -1,4 +1,4 @@
-name: Build and test on latest Ubuntu and Java 11
+name: Build and test on latest Windows and Java 11
 
 on:
   push:
@@ -11,14 +11,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
+    - name: Grant execute permission for mvnw
+      run: chmod +x mvnw
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: ./mvnw -B package --file pom.xml
+

--- a/.github/workflows/windows_java-17.yml
+++ b/.github/workflows/windows_java-17.yml
@@ -1,4 +1,4 @@
-name: Build and test on latest Windows and Java 11
+name: Build and test on latest Windows and Java 17
 
 on:
   push:

--- a/graphwalker-core/pom.xml
+++ b/graphwalker-core/pom.xml
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
+      <artifactId>js-language</artifactId>
     </dependency>
     <dependency>
       <groupId>org.graalvm.js</groupId>

--- a/graphwalker-studio/pom.xml
+++ b/graphwalker-studio/pom.xml
@@ -68,7 +68,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>1.15.0</version>
+        <version>1.15.1</version>
         <configuration>
           <installDirectory>target</installDirectory>
         </configuration>

--- a/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketServerTest.java
+++ b/graphwalker-websocket/src/test/java/org/graphwalker/websocket/WebSocketServerTest.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import static com.ibm.icu.impl.Assert.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;

--- a/pom.xml
+++ b/pom.xml
@@ -73,10 +73,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <doclint>none</doclint>
-    <spring.version>2.7.9</spring.version>
+    <spring.version>3.3.4</spring.version>
     <maven.version>3.8.3</maven.version>
-    <antlr.version>4.13.1</antlr.version>
-    <graalvm.version>22.3.5</graalvm.version>
+    <antlr.version>4.13.2</antlr.version>
+    <graalvm.version>24.1.0</graalvm.version>
   </properties>
 
   <modules>
@@ -155,7 +155,7 @@
       </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId>
-        <artifactId>js</artifactId>
+        <artifactId>js-language</artifactId>
         <version>${graalvm.version}</version>
       </dependency>
       <dependency>
@@ -171,7 +171,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.16.1</version>
+	<version>2.17.0</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>
@@ -186,7 +186,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.8</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -206,7 +206,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.174</version>
+        <version>4.8.176</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.javaparser</groupId>
@@ -221,7 +221,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.14.0</version>
+        <version>3.17.0</version>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>
@@ -231,7 +231,7 @@
       <dependency>
         <groupId>org.java-websocket</groupId>
         <artifactId>Java-WebSocket</artifactId>
-        <version>1.5.6</version>
+        <version>1.5.7</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>
@@ -241,7 +241,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.2.1-jre</version>
+        <version>33.3.1-jre</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -480,7 +480,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -500,12 +500,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>4.0.0-M15</version>
+          <version>4.0.0-M16</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.7.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -515,7 +515,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>3.2.4</version>
+          <version>3.2.6</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -530,12 +530,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.1.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -555,7 +555,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.2.1</version>
+	  <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.antlr</groupId>


### PR DESCRIPTION
The upgrade to Java 17 is because of Spring Framework 6 for which the minimum supported Java version is Java 17.
Spring is used by graphwalker-studio, and not needed by the other modules of graphwalker.

If anyone needs backward java compatibility, downgrade spring version in projects root `pom.xml` to
`<spring.version>2.7.9</spring.version>`
